### PR TITLE
[FEATURE] Spend limits + rate limiter + identity docs - Fixes #239, #195

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -819,6 +819,67 @@ class InvalidProjectStatusError(APIError):
         self.valid_statuses = valid_statuses
 
 
+class PerTransactionLimitExceededError(APIError):
+    """
+    Raised when a single transaction amount exceeds the configured per-tx limit.
+
+    Issue #239: Per-transaction spend limit enforcement.
+
+    Returns:
+        - HTTP 422 (Unprocessable Entity)
+        - error_code: PER_TX_LIMIT_EXCEEDED
+        - detail: Message identifying the agent and the overage
+    """
+
+    def __init__(self, agent_id: str, amount: "Any", max_per_tx: "Any"):
+        from decimal import Decimal
+        try:
+            overage = Decimal(str(amount)) - Decimal(str(max_per_tx))
+        except Exception:
+            overage = None
+        overage_str = f" (overage: {overage})" if overage is not None else ""
+        detail = (
+            f"Per-transaction limit exceeded for agent '{agent_id}'. "
+            f"Requested: {amount}, limit: {max_per_tx}{overage_str}."
+        )
+        super().__init__(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            error_code="PER_TX_LIMIT_EXCEEDED",
+            detail=detail,
+        )
+        self.agent_id = agent_id
+        self.amount = amount
+        self.max_per_tx = max_per_tx
+
+
+class RateLimitExceededError(APIError):
+    """
+    Raised when an agent DID exceeds the allowed request rate.
+
+    Issue #239: Sliding-window rate limiting enforcement.
+
+    Returns:
+        - HTTP 429 (Too Many Requests)
+        - error_code: RATE_LIMIT_EXCEEDED
+        - Retry-After header seconds via retry_after_seconds attribute
+    """
+
+    def __init__(self, did: str, retry_after_seconds: int = 60):
+        detail = (
+            f"Rate limit exceeded for '{did}'. "
+            f"Retry after {retry_after_seconds} seconds."
+        )
+        headers = {"Retry-After": str(retry_after_seconds)}
+        super().__init__(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            error_code="RATE_LIMIT_EXCEEDED",
+            detail=detail,
+            headers=headers,
+        )
+        self.did = did
+        self.retry_after_seconds = retry_after_seconds
+
+
 def format_error_response(error_code: str, detail: str) -> Dict[str, str]:
     """
     Format error response per DX Contract.

--- a/backend/app/middleware/rate_limiter.py
+++ b/backend/app/middleware/rate_limiter.py
@@ -1,0 +1,154 @@
+"""
+Rate limiter middleware for FastAPI.
+Issue #239: Agent Spend Limits — per-DID request throttling at the HTTP layer.
+
+Extracts the agent DID from the ``X-Agent-DID`` header (or falls back to the
+``sub`` claim of a decoded JWT Bearer token), then delegates to
+``RateLimiterService.check_rate_limit()``.  Returns HTTP 429 with a
+``Retry-After`` header when the limit is exceeded.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from fastapi import Request, Response, status
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.errors import RateLimitExceededError, format_error_response
+from app.services.rate_limiter_service import RateLimiterService
+
+logger = logging.getLogger(__name__)
+
+# Default rate-limit parameters — may be overridden per-deployment via env/config
+DEFAULT_MAX_REQUESTS: int = 100
+DEFAULT_WINDOW_SECONDS: int = 60
+
+# Paths that bypass rate limiting (health-checks, docs, etc.)
+_EXEMPT_PATHS = frozenset(
+    {
+        "/",
+        "/health",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+        "/.well-known/x402",
+        "/x402",
+        "/v1/public/auth/login",
+        "/v1/public/auth/refresh",
+        "/v1/public/embeddings/models",
+    }
+)
+
+
+class RateLimiterMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that enforces per-DID sliding-window rate limits.
+
+    DID resolution order:
+    1. ``X-Agent-DID`` request header (preferred — explicit agent identity)
+    2. ``sub`` claim extracted from a JWT ``Authorization: Bearer …`` header
+    3. If no DID can be resolved the request passes through without limiting
+       (authentication middleware handles missing identity separately).
+
+    On limit exceeded the middleware short-circuits with:
+    - HTTP 429 Too Many Requests
+    - ``Retry-After`` header set to the number of seconds until the window resets
+    - JSON body: ``{ detail, error_code, retry_after_seconds }``
+    """
+
+    def __init__(
+        self,
+        app,
+        rate_limiter: Optional[RateLimiterService] = None,
+        max_requests: int = DEFAULT_MAX_REQUESTS,
+        window_seconds: int = DEFAULT_WINDOW_SECONDS,
+    ) -> None:
+        super().__init__(app)
+        self._rate_limiter = rate_limiter or RateLimiterService()
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """
+        Intercept the request, extract the DID, and apply rate limiting.
+
+        Args:
+            request: Incoming HTTP request.
+            call_next: Next middleware or route handler.
+
+        Returns:
+            429 JSONResponse on limit exceeded, otherwise the downstream response.
+        """
+        path = request.url.path
+
+        # Exempt paths bypass rate limiting
+        if path in _EXEMPT_PATHS:
+            return await call_next(request)
+
+        did = self._extract_did(request)
+
+        if did is None:
+            # No DID available — pass through; auth middleware handles identity
+            return await call_next(request)
+
+        try:
+            await self._rate_limiter.check_rate_limit(
+                did=did,
+                max_requests=self._max_requests,
+                window_seconds=self._window_seconds,
+            )
+        except RateLimitExceededError as exc:
+            logger.warning(
+                f"Rate limit triggered for DID '{did}' on path '{path}'.",
+                extra={"did": did, "path": path, "retry_after": exc.retry_after_seconds},
+            )
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={
+                    **format_error_response(
+                        error_code=exc.error_code,
+                        detail=exc.detail,
+                    ),
+                    "retry_after_seconds": exc.retry_after_seconds,
+                },
+                headers={"Retry-After": str(exc.retry_after_seconds)},
+            )
+
+        return await call_next(request)
+
+    @staticmethod
+    def _extract_did(request: Request) -> Optional[str]:
+        """
+        Extract the agent DID from the request.
+
+        Checks ``X-Agent-DID`` header first, then falls back to the ``sub``
+        claim of a JWT Bearer token in the ``Authorization`` header.
+
+        Args:
+            request: Incoming HTTP request.
+
+        Returns:
+            DID string or None if no DID can be resolved.
+        """
+        # Preferred: explicit DID header
+        did = request.headers.get("X-Agent-DID")
+        if did:
+            return did.strip()
+
+        # Fallback: decode JWT and use the ``sub`` claim
+        authorization = request.headers.get("Authorization", "")
+        if authorization.startswith("Bearer "):
+            token = authorization[len("Bearer "):]
+            try:
+                # Lazy import to avoid circular dependencies
+                from app.core.jwt import decode_access_token
+                token_data = decode_access_token(token)
+                if token_data and token_data.user_id:
+                    return token_data.user_id
+            except Exception:
+                # Non-fatal — token may be invalid; auth middleware handles that
+                pass
+
+        return None

--- a/backend/app/schemas/spend_limits.py
+++ b/backend/app/schemas/spend_limits.py
@@ -1,0 +1,63 @@
+"""
+Pydantic schemas for agent spend limits and rate limiting.
+Issue #239: Agent Spend Limits Enforcement.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class SpendLimitConfig(BaseModel):
+    """Configuration for agent spend and rate limits."""
+
+    max_daily_spend: Optional[Decimal] = Field(
+        None,
+        description="Maximum total spend per UTC calendar day in USDC. None = unlimited.",
+        ge=0,
+    )
+    max_per_tx_spend: Optional[Decimal] = Field(
+        None,
+        description="Maximum spend per single transaction in USDC. None = unlimited.",
+        ge=0,
+    )
+    max_requests_per_minute: Optional[int] = Field(
+        None,
+        description="Maximum API requests per 60-second sliding window. None = unlimited.",
+        ge=1,
+    )
+
+
+class SpendLimitStatus(BaseModel):
+    """Current spend and rate limit status for an agent."""
+
+    agent_id: str = Field(..., description="Agent DID or identifier.")
+    daily_spend: Decimal = Field(..., description="Total confirmed spend today (UTC).")
+    remaining_daily: Optional[Decimal] = Field(
+        None,
+        description="Remaining daily budget. None when no daily limit is configured.",
+    )
+    per_tx_limit: Optional[Decimal] = Field(
+        None,
+        description="Per-transaction limit. None when no per-tx limit is configured.",
+    )
+    requests_this_minute: int = Field(
+        0,
+        description="Number of API requests made in the current 60-second window.",
+    )
+
+
+class RateLimitExceededResponse(BaseModel):
+    """Response body returned when a rate limit is exceeded (HTTP 429)."""
+
+    detail: str = Field(..., description="Human-readable explanation of the rate limit.")
+    error_code: str = Field(
+        "RATE_LIMIT_EXCEEDED",
+        description="Machine-readable error code.",
+    )
+    retry_after_seconds: int = Field(
+        ...,
+        description="Number of seconds the client should wait before retrying.",
+        ge=1,
+    )

--- a/backend/app/services/rate_limiter_service.py
+++ b/backend/app/services/rate_limiter_service.py
@@ -1,0 +1,107 @@
+"""
+Sliding-window rate limiter service for per-DID request throttling.
+Issue #239: Agent Spend Limits — rate limiting enforcement.
+
+Implements an in-memory sliding window rate limiter with asyncio.Lock
+for thread safety and optional ZeroDB fallback for distributed state.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Dict, List, Optional, Any
+
+from app.core.errors import RateLimitExceededError
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimiterService:
+    """
+    In-memory sliding-window rate limiter keyed by agent DID.
+
+    Each DID maintains a list of request timestamps (monotonic clock).
+    On every call the list is pruned to discard entries older than
+    ``window_seconds``, then the remaining count is compared to
+    ``max_requests``.
+
+    Thread safety is guaranteed by a per-instance ``asyncio.Lock``.
+    """
+
+    def __init__(self, client: Optional[Any] = None) -> None:
+        """
+        Initialise the rate limiter.
+
+        Args:
+            client: Optional ZeroDB client (reserved for future distributed
+                    state fallback; not used in the current in-memory impl).
+        """
+        self._client = client
+        # Mapping of DID -> list of monotonic timestamps
+        self._store: Dict[str, List[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def check_rate_limit(
+        self,
+        did: str,
+        max_requests: int = 100,
+        window_seconds: int = 60,
+    ) -> bool:
+        """
+        Check whether a DID is within its allowed request rate.
+
+        Prunes timestamps outside the sliding window, counts remaining
+        entries, and either records a new timestamp (allowed) or raises
+        ``RateLimitExceededError`` (denied).
+
+        Args:
+            did: Agent DID — the rate-limit key.
+            max_requests: Maximum number of requests permitted within the window.
+            window_seconds: Length of the sliding window in seconds.
+
+        Returns:
+            True when the request is within the allowed rate.
+
+        Raises:
+            RateLimitExceededError: When the DID has exceeded ``max_requests``
+                within the current ``window_seconds`` window.
+        """
+        now = time.monotonic()
+        cutoff = now - window_seconds
+
+        async with self._lock:
+            # Initialise entry for new DIDs
+            if did not in self._store:
+                self._store[did] = []
+
+            timestamps = self._store[did]
+
+            # Prune expired timestamps (sliding window)
+            pruned = [ts for ts in timestamps if ts > cutoff]
+            self._store[did] = pruned
+
+            if len(pruned) >= max_requests:
+                # Calculate earliest expiry so callers know when to retry
+                oldest = min(pruned)
+                retry_after = max(1, int(oldest + window_seconds - now) + 1)
+                logger.warning(
+                    f"Rate limit exceeded for DID '{did}': "
+                    f"{len(pruned)}/{max_requests} requests in {window_seconds}s window.",
+                    extra={"did": did, "count": len(pruned), "limit": max_requests},
+                )
+                raise RateLimitExceededError(did=did, retry_after_seconds=retry_after)
+
+            # Record this request
+            self._store[did].append(now)
+
+        logger.debug(
+            f"Rate limit check passed for DID '{did}': "
+            f"{len(self._store[did])}/{max_requests} requests.",
+            extra={"did": did, "limit": max_requests},
+        )
+        return True
+
+
+# Global singleton — tests inject a fresh instance via constructor
+rate_limiter_service = RateLimiterService()

--- a/backend/app/services/spend_tracking_service.py
+++ b/backend/app/services/spend_tracking_service.py
@@ -1,15 +1,19 @@
 """
 Spend Tracking Service for per-agent daily budget enforcement.
 Issue #153: Implement per-agent daily spending limits.
+Issue #239: Per-transaction spend limit enforcement.
 
 This service handles:
 - Tracking daily spend per agent
 - Checking if a payment would exceed daily budget
+- Enforcing per-transaction spend limits
 - Calculating remaining budget
 - Resetting daily spend at midnight UTC
 
 Uses ZeroDB for persistence via the agent_spend_tracking table.
 """
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
@@ -189,6 +193,56 @@ class SpendTrackingService:
 
 
 
+    async def check_per_transaction_limit(
+        self,
+        agent_id: str,
+        amount: Decimal,
+        max_per_tx: Optional[Decimal],
+    ) -> bool:
+        """
+        Check that a single transaction amount does not exceed the per-tx limit.
+
+        Issue #239: Per-transaction spend limit enforcement.
+
+        Args:
+            agent_id: Agent DID or identifier
+            amount: Transaction amount to validate
+            max_per_tx: Maximum allowed per-transaction spend (None = unlimited)
+
+        Returns:
+            True if the amount is within the limit
+
+        Raises:
+            PerTransactionLimitExceededError: When amount exceeds max_per_tx
+        """
+        from app.core.errors import PerTransactionLimitExceededError
+
+        if max_per_tx is None:
+            logger.info(
+                f"Per-tx check passed for agent {agent_id}: no limit configured",
+                extra={"agent_id": agent_id, "amount": str(amount)},
+            )
+            return True
+
+        if amount <= max_per_tx:
+            logger.info(
+                f"Per-tx check passed for agent {agent_id}: "
+                f"amount={amount} <= limit={max_per_tx}",
+                extra={"agent_id": agent_id, "amount": str(amount), "max_per_tx": str(max_per_tx)},
+            )
+            return True
+
+        logger.warning(
+            f"Per-tx check BLOCKED for agent {agent_id}: "
+            f"amount={amount} exceeds limit={max_per_tx}",
+            extra={"agent_id": agent_id, "amount": str(amount), "max_per_tx": str(max_per_tx)},
+        )
+        raise PerTransactionLimitExceededError(
+            agent_id=agent_id,
+            amount=amount,
+            max_per_tx=max_per_tx,
+        )
+
     async def get_monthly_spend(
         self,
         agent_id: str,
@@ -279,11 +333,15 @@ class SpendTrackingService:
         project_id: str,
         amount: Decimal,
         daily_limit: Optional[Decimal] = None,
-        monthly_limit: Optional[Decimal] = None
+        monthly_limit: Optional[Decimal] = None,
+        max_per_tx: Optional[Decimal] = None,
     ) -> Dict[str, Any]:
         """
-        Check both daily and monthly budgets.
-        Transaction must pass BOTH checks.
+        Check daily, monthly, and per-transaction budgets.
+        Transaction must pass ALL configured checks.
+
+        Issue #153: Daily and monthly limit enforcement.
+        Issue #239: Per-transaction limit enforcement added.
 
         Args:
             agent_id: Agent identifier
@@ -291,16 +349,29 @@ class SpendTrackingService:
             amount: Transaction amount to check
             daily_limit: Optional daily spending limit in USDC
             monthly_limit: Optional monthly spending limit in USDC
+            max_per_tx: Optional per-transaction spending limit in USDC
 
         Returns:
             Dict with:
-                - allowed: bool (True only if both limits pass)
+                - allowed: bool (True only if all configured limits pass)
                 - violations: List of limit violations with details
         """
-        results = {
+        results: Dict[str, Any] = {
             "allowed": True,
-            "violations": []
+            "violations": [],
         }
+
+        # Check per-transaction limit first (cheapest check — no DB query)
+        if max_per_tx is not None and amount > max_per_tx:
+            results["allowed"] = False
+            results["violations"].append({
+                "type": "per_tx_limit_exceeded",
+                "details": {
+                    "amount": amount,
+                    "max_per_tx": max_per_tx,
+                    "exceeded_by": amount - max_per_tx,
+                },
+            })
 
         # Check daily limit if provided
         if daily_limit is not None:
@@ -311,7 +382,7 @@ class SpendTrackingService:
                 results["allowed"] = False
                 results["violations"].append({
                     "type": "daily_limit_exceeded",
-                    "details": daily_check
+                    "details": daily_check,
                 })
 
         # Check monthly limit if provided
@@ -323,7 +394,7 @@ class SpendTrackingService:
                 results["allowed"] = False
                 results["violations"].append({
                     "type": "monthly_limit_exceeded",
-                    "details": monthly_check
+                    "details": monthly_check,
                 })
 
         return results

--- a/backend/app/tests/test_agent_spend_limits.py
+++ b/backend/app/tests/test_agent_spend_limits.py
@@ -1,0 +1,203 @@
+"""
+Tests for per-transaction spend limit enforcement.
+Issues #239: Agent Spend Limits Enforcement — per-transaction check.
+
+TDD: RED phase — tests written before implementation.
+"""
+from __future__ import annotations
+
+import pytest
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Optional, Dict, Any
+
+
+class DescribeCheckPerTransactionLimit:
+    """Describe SpendTrackingService.check_per_transaction_limit behavior."""
+
+    def _make_service(self):
+        """Helper: return service with a mocked ZeroDB client."""
+        from app.services.spend_tracking_service import SpendTrackingService
+        mock_client = MagicMock()
+        return SpendTrackingService(client=mock_client)
+
+    @pytest.mark.asyncio
+    async def it_returns_true_when_amount_is_below_limit(self):
+        """Amount strictly less than max_per_tx should return True."""
+        svc = self._make_service()
+        result = await svc.check_per_transaction_limit(
+            agent_id="did:hedera:testnet:agent-1",
+            amount=Decimal("5.00"),
+            max_per_tx=Decimal("10.00"),
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_returns_true_when_amount_equals_limit(self):
+        """Amount exactly equal to max_per_tx should return True (boundary)."""
+        svc = self._make_service()
+        result = await svc.check_per_transaction_limit(
+            agent_id="did:hedera:testnet:agent-1",
+            amount=Decimal("10.00"),
+            max_per_tx=Decimal("10.00"),
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_raises_when_amount_exceeds_limit(self):
+        """Amount exceeding max_per_tx must raise PerTransactionLimitExceededError."""
+        from app.core.errors import APIError
+        svc = self._make_service()
+        with pytest.raises(APIError) as exc_info:
+            await svc.check_per_transaction_limit(
+                agent_id="did:hedera:testnet:agent-1",
+                amount=Decimal("15.00"),
+                max_per_tx=Decimal("10.00"),
+            )
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.error_code == "PER_TX_LIMIT_EXCEEDED"
+
+    @pytest.mark.asyncio
+    async def it_raises_with_agent_id_in_detail(self):
+        """Error detail must include the agent_id for traceability."""
+        from app.core.errors import APIError
+        svc = self._make_service()
+        agent_id = "did:hedera:testnet:agent-trace"
+        with pytest.raises(APIError) as exc_info:
+            await svc.check_per_transaction_limit(
+                agent_id=agent_id,
+                amount=Decimal("99.99"),
+                max_per_tx=Decimal("50.00"),
+            )
+        assert agent_id in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def it_raises_with_exceeded_amount_in_detail(self):
+        """Error detail must state how much the transaction exceeds the limit."""
+        from app.core.errors import APIError
+        svc = self._make_service()
+        with pytest.raises(APIError) as exc_info:
+            await svc.check_per_transaction_limit(
+                agent_id="did:hedera:testnet:agent-1",
+                amount=Decimal("20.00"),
+                max_per_tx=Decimal("10.00"),
+            )
+        # Detail should mention the overage (10.00) or at least the amounts
+        assert "10.00" in exc_info.value.detail or "20.00" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def it_returns_true_when_no_limit_configured(self):
+        """None max_per_tx means unlimited — must return True for any amount."""
+        svc = self._make_service()
+        result = await svc.check_per_transaction_limit(
+            agent_id="did:hedera:testnet:agent-1",
+            amount=Decimal("999999.00"),
+            max_per_tx=None,
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_raises_for_zero_amount_below_positive_limit(self):
+        """Zero amount is always within any positive limit."""
+        svc = self._make_service()
+        result = await svc.check_per_transaction_limit(
+            agent_id="did:hedera:testnet:agent-1",
+            amount=Decimal("0.00"),
+            max_per_tx=Decimal("10.00"),
+        )
+        assert result is True
+
+
+class DescribeCombinedDailyAndPerTxLimits:
+    """
+    Describe check_combined_budget with both daily and per-tx limits applied.
+    Issue #239: daily + per-tx combination enforcement.
+    """
+
+    def _make_service_with_daily_spend(self, daily_spend: Decimal):
+        """Helper: service whose get_daily_spend returns a fixed value."""
+        from app.services.spend_tracking_service import SpendTrackingService
+        mock_client = MagicMock()
+        svc = SpendTrackingService(client=mock_client)
+        svc.get_daily_spend = AsyncMock(return_value=daily_spend)
+        return svc
+
+    @pytest.mark.asyncio
+    async def it_allows_when_both_limits_pass(self):
+        """Transaction within both daily and per-tx limits must be allowed."""
+        svc = self._make_service_with_daily_spend(Decimal("30.00"))
+        result = await svc.check_combined_budget(
+            agent_id="did:hedera:testnet:agent-1",
+            project_id="proj-1",
+            amount=Decimal("5.00"),
+            daily_limit=Decimal("100.00"),
+            monthly_limit=None,
+            max_per_tx=Decimal("20.00"),
+        )
+        assert result["allowed"] is True
+        assert result["violations"] == []
+
+    @pytest.mark.asyncio
+    async def it_blocks_when_per_tx_limit_exceeded_even_if_daily_ok(self):
+        """Per-tx violation must block even when daily budget has room."""
+        svc = self._make_service_with_daily_spend(Decimal("10.00"))
+        result = await svc.check_combined_budget(
+            agent_id="did:hedera:testnet:agent-1",
+            project_id="proj-1",
+            amount=Decimal("50.00"),
+            daily_limit=Decimal("100.00"),
+            monthly_limit=None,
+            max_per_tx=Decimal("20.00"),
+        )
+        assert result["allowed"] is False
+        violation_types = [v["type"] for v in result["violations"]]
+        assert "per_tx_limit_exceeded" in violation_types
+
+    @pytest.mark.asyncio
+    async def it_blocks_when_daily_limit_exceeded_even_if_per_tx_ok(self):
+        """Daily limit violation must block even when per-tx is within limit."""
+        svc = self._make_service_with_daily_spend(Decimal("95.00"))
+        result = await svc.check_combined_budget(
+            agent_id="did:hedera:testnet:agent-1",
+            project_id="proj-1",
+            amount=Decimal("10.00"),
+            daily_limit=Decimal("100.00"),
+            monthly_limit=None,
+            max_per_tx=Decimal("20.00"),
+        )
+        assert result["allowed"] is False
+        violation_types = [v["type"] for v in result["violations"]]
+        assert "daily_limit_exceeded" in violation_types
+
+    @pytest.mark.asyncio
+    async def it_reports_both_violations_when_both_limits_exceeded(self):
+        """Both per-tx and daily violations must both appear in result."""
+        svc = self._make_service_with_daily_spend(Decimal("95.00"))
+        result = await svc.check_combined_budget(
+            agent_id="did:hedera:testnet:agent-1",
+            project_id="proj-1",
+            amount=Decimal("50.00"),
+            daily_limit=Decimal("100.00"),
+            monthly_limit=None,
+            max_per_tx=Decimal("20.00"),
+        )
+        assert result["allowed"] is False
+        violation_types = [v["type"] for v in result["violations"]]
+        assert "per_tx_limit_exceeded" in violation_types
+        assert "daily_limit_exceeded" in violation_types
+
+    @pytest.mark.asyncio
+    async def it_ignores_per_tx_limit_when_none(self):
+        """When max_per_tx is None, no per-tx violation should be reported."""
+        svc = self._make_service_with_daily_spend(Decimal("10.00"))
+        result = await svc.check_combined_budget(
+            agent_id="did:hedera:testnet:agent-1",
+            project_id="proj-1",
+            amount=Decimal("500.00"),
+            daily_limit=Decimal("1000.00"),
+            monthly_limit=None,
+            max_per_tx=None,
+        )
+        assert result["allowed"] is True
+        violation_types = [v["type"] for v in result["violations"]]
+        assert "per_tx_limit_exceeded" not in violation_types

--- a/backend/app/tests/test_rate_limiter_service.py
+++ b/backend/app/tests/test_rate_limiter_service.py
@@ -1,0 +1,193 @@
+"""
+Tests for RateLimiterService — sliding window rate limiting.
+Issue #239: Agent Spend Limits — rate limiting enforcement.
+
+TDD: RED phase — tests written before implementation.
+"""
+from __future__ import annotations
+
+import asyncio
+import pytest
+import time
+from typing import Optional, Dict, Any
+from unittest.mock import AsyncMock, MagicMock
+
+
+class DescribeRateLimiterServiceInit:
+    """Describe RateLimiterService construction and defaults."""
+
+    def it_can_be_instantiated_without_arguments(self):
+        """RateLimiterService must be constructable with no args."""
+        from app.services.rate_limiter_service import RateLimiterService
+        svc = RateLimiterService()
+        assert svc is not None
+
+    def it_accepts_optional_zerodb_client(self):
+        """Constructor accepts an optional client for testing."""
+        from app.services.rate_limiter_service import RateLimiterService
+        mock_client = MagicMock()
+        svc = RateLimiterService(client=mock_client)
+        assert svc is not None
+
+
+class DescribeCheckRateLimit:
+    """Describe RateLimiterService.check_rate_limit sliding-window behavior."""
+
+    def _make_service(self):
+        from app.services.rate_limiter_service import RateLimiterService
+        return RateLimiterService(client=None)
+
+    @pytest.mark.asyncio
+    async def it_returns_true_for_first_request(self):
+        """First request from a DID is always allowed."""
+        svc = self._make_service()
+        result = await svc.check_rate_limit(
+            did="did:hedera:testnet:new-agent",
+            max_requests=10,
+            window_seconds=60,
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_returns_true_within_the_request_limit(self):
+        """Requests up to max_requests within window must all return True."""
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-within-limit"
+        for _ in range(5):
+            result = await svc.check_rate_limit(
+                did=did,
+                max_requests=10,
+                window_seconds=60,
+            )
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def it_raises_429_when_limit_exceeded(self):
+        """Exceeding max_requests within window must raise RateLimitExceededError."""
+        from app.services.rate_limiter_service import RateLimitExceededError
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-over-limit"
+        # Exhaust the limit
+        for _ in range(3):
+            await svc.check_rate_limit(did=did, max_requests=3, window_seconds=60)
+        # Next request must raise
+        with pytest.raises(RateLimitExceededError):
+            await svc.check_rate_limit(did=did, max_requests=3, window_seconds=60)
+
+    @pytest.mark.asyncio
+    async def it_raises_error_with_correct_http_status(self):
+        """RateLimitExceededError must carry HTTP 429."""
+        from app.services.rate_limiter_service import RateLimitExceededError
+        from app.core.errors import APIError
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-429"
+        for _ in range(2):
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=60)
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=60)
+        assert exc_info.value.status_code == 429
+
+    @pytest.mark.asyncio
+    async def it_raises_error_with_rate_limit_exceeded_error_code(self):
+        """RateLimitExceededError must carry RATE_LIMIT_EXCEEDED error_code."""
+        from app.services.rate_limiter_service import RateLimitExceededError
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-code"
+        for _ in range(2):
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=60)
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=60)
+        assert exc_info.value.error_code == "RATE_LIMIT_EXCEEDED"
+
+    @pytest.mark.asyncio
+    async def it_exposes_retry_after_seconds_on_error(self):
+        """RateLimitExceededError must expose retry_after_seconds attribute."""
+        from app.services.rate_limiter_service import RateLimitExceededError
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-retry"
+        for _ in range(2):
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=30)
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            await svc.check_rate_limit(did=did, max_requests=2, window_seconds=30)
+        assert hasattr(exc_info.value, "retry_after_seconds")
+        assert exc_info.value.retry_after_seconds > 0
+
+    @pytest.mark.asyncio
+    async def it_tracks_different_dids_independently(self):
+        """Requests for different DIDs must not share rate limit state."""
+        svc = self._make_service()
+        did_a = "did:hedera:testnet:agent-a"
+        did_b = "did:hedera:testnet:agent-b"
+        # Exhaust limit for agent-a
+        for _ in range(2):
+            await svc.check_rate_limit(did=did_a, max_requests=2, window_seconds=60)
+        # agent-b still has quota
+        result = await svc.check_rate_limit(did=did_b, max_requests=2, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_prunes_expired_timestamps_from_sliding_window(self):
+        """Timestamps older than window_seconds must be pruned, freeing quota."""
+        from app.services.rate_limiter_service import RateLimiterService
+        svc = RateLimiterService(client=None)
+        did = "did:hedera:testnet:agent-expire"
+        # Manually inject old timestamps to simulate a past window
+        old_time = time.monotonic() - 120  # 2 minutes ago
+        svc._store[did] = [old_time, old_time, old_time]
+        # New request in a 60s window should succeed (old ones pruned)
+        result = await svc.check_rate_limit(did=did, max_requests=2, window_seconds=60)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def it_uses_default_max_requests_100_and_window_60(self):
+        """Default parameters must be max_requests=100 and window_seconds=60."""
+        svc = self._make_service()
+        did = "did:hedera:testnet:agent-defaults"
+        # Single call with no explicit params should not raise
+        result = await svc.check_rate_limit(did=did)
+        assert result is True
+
+
+class DescribeRateLimiterConcurrency:
+    """Describe RateLimiterService thread-safety with asyncio.Lock."""
+
+    @pytest.mark.asyncio
+    async def it_handles_concurrent_requests_safely(self):
+        """Concurrent calls for the same DID must not exceed the limit."""
+        from app.services.rate_limiter_service import RateLimiterService, RateLimitExceededError
+        svc = RateLimiterService(client=None)
+        did = "did:hedera:testnet:agent-concurrent"
+        max_requests = 5
+
+        results = []
+        errors = []
+
+        async def make_request():
+            try:
+                r = await svc.check_rate_limit(
+                    did=did, max_requests=max_requests, window_seconds=60
+                )
+                results.append(r)
+            except RateLimitExceededError:
+                errors.append(True)
+
+        # Fire 10 concurrent requests; only 5 should succeed
+        await asyncio.gather(*[make_request() for _ in range(10)])
+        assert len(results) == max_requests
+        assert len(errors) == 10 - max_requests
+
+
+class DescribeRateLimiterMiddlewareIntegration:
+    """Describe the rate limiter middleware return shape for 429 responses."""
+
+    @pytest.mark.asyncio
+    async def it_raises_error_that_includes_did_in_detail(self):
+        """Error detail must name the DID that was rate-limited."""
+        from app.services.rate_limiter_service import RateLimiterService, RateLimitExceededError
+        svc = RateLimiterService(client=None)
+        did = "did:hedera:testnet:agent-detail"
+        for _ in range(1):
+            await svc.check_rate_limit(did=did, max_requests=1, window_seconds=60)
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            await svc.check_rate_limit(did=did, max_requests=1, window_seconds=60)
+        assert did in exc_info.value.detail

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 testpaths = app/tests
 python_files = test_*.py
-python_classes = Test*
-python_functions = test_*
+python_classes = Test* Describe*
+python_functions = test_* it_*
 addopts =
     -v
     --tb=short

--- a/docs/api/HEDERA_IDENTITY_API.md
+++ b/docs/api/HEDERA_IDENTITY_API.md
@@ -1,0 +1,224 @@
+# Hedera Identity API Reference
+
+Issue #195: Agent Identity Documentation — API reference.
+
+Base URL: `https://api.ainative.studio/api/v1`
+
+All endpoints require `X-API-Key` or `Authorization: Bearer <jwt>` unless stated otherwise.
+
+---
+
+## Endpoints
+
+- [POST /agents/register](#post-agentsregister)
+- [GET /agents/{id}/did](#get-agentsiddid)
+- [POST /agents/directory/search](#post-agentsdirectorysearch)
+
+---
+
+## POST /agents/register
+
+Register an agent as an HTS NFT with a `did:hedera` identifier.
+
+This endpoint:
+1. Generates an Ed25519 keypair for the agent.
+2. Creates an HCS topic to anchor the DID document.
+3. Mints one NFT from the shared agent registry token.
+4. Publishes the DID document as an HCS message.
+5. Submits an HCS-14 registration message to the directory topic.
+6. Persists the agent record in ZeroDB (append-only).
+
+### Request
+
+```
+POST /api/v1/agents/register
+Content-Type: application/json
+X-API-Key: <key>
+```
+
+**Body:**
+
+```json
+{
+  "name": "FinanceResearcher-v1",
+  "capabilities": [
+    "payment.initiate",
+    "market.read",
+    "compliance.report"
+  ],
+  "endpoint": "https://api.ainative.studio/agents/finance-researcher",
+  "metadata": {
+    "version": "1.0.0",
+    "owner_account": "0.0.12345"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable agent name (max 64 chars) |
+| `capabilities` | string[] | Yes | AAP capability strings (min 1) |
+| `endpoint` | string | No | Service endpoint URL for the DID document |
+| `metadata` | object | No | Arbitrary key-value metadata stored in NFT |
+
+### Response `201 Created`
+
+```json
+{
+  "agent_id": "did:hedera:testnet:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp_0.0.98765",
+  "did": "did:hedera:testnet:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp_0.0.98765",
+  "nft_serial": 42,
+  "hcs_topic_id": "0.0.98765",
+  "public_key": "z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+  "created_at": "2026-04-03T12:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Canonical agent identifier (same as `did`) |
+| `did` | string | Full `did:hedera` DID |
+| `nft_serial` | integer | HTS NFT serial number |
+| `hcs_topic_id` | string | Hedera topic that anchors the DID document |
+| `public_key` | string | Base58btc-encoded Ed25519 public key |
+| `created_at` | string | ISO 8601 UTC timestamp |
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 409 | `DUPLICATE_AGENT_DID` | DID already registered in this project |
+| 422 | `SCHEMA_VALIDATION_ERROR` | Missing or invalid request fields |
+| 502 | `HEDERA_NETWORK_ERROR` | Hedera SDK call failed |
+
+---
+
+## GET /agents/{id}/did
+
+Resolve a `did:hedera` DID document for a registered agent.
+
+### Request
+
+```
+GET /api/v1/agents/{id}/did
+X-API-Key: <key>
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Agent DID or numeric agent ID |
+
+**Example:**
+
+```
+GET /api/v1/agents/did:hedera:testnet:z6Mk..._0.0.98765/did
+```
+
+### Response `200 OK`
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:hedera:testnet:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp_0.0.98765",
+  "verificationMethod": [
+    {
+      "id": "did:hedera:testnet:z6Mk..._0.0.98765#key-1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:hedera:testnet:z6Mk..._0.0.98765",
+      "publicKeyMultibase": "z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+    }
+  ],
+  "authentication": ["#key-1"],
+  "service": [
+    {
+      "id": "#agent-endpoint",
+      "type": "AgentService",
+      "serviceEndpoint": "https://api.ainative.studio/agents/finance-researcher"
+    },
+    {
+      "id": "#capabilities",
+      "type": "AAPCapabilitySet",
+      "serviceEndpoint": {
+        "capabilities": ["payment.initiate", "market.read"],
+        "aap_version": "1.0"
+      }
+    }
+  ],
+  "resolved_at": "2026-04-03T12:01:00Z"
+}
+```
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 404 | `AGENT_NOT_FOUND` | No agent with the provided ID |
+| 502 | `HEDERA_NETWORK_ERROR` | Could not fetch HCS messages for DID resolution |
+
+---
+
+## POST /agents/directory/search
+
+Query the HCS-14 agent directory.  Returns agents matching the requested
+capability filters, optionally filtered by name or DID prefix.
+
+### Request
+
+```
+POST /api/v1/agents/directory/search
+Content-Type: application/json
+X-API-Key: <key>
+```
+
+**Body:**
+
+```json
+{
+  "capabilities": ["payment.initiate"],
+  "name_contains": "Finance",
+  "limit": 20,
+  "offset": 0
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `capabilities` | string[] | No | Return only agents with ALL listed capabilities |
+| `name_contains` | string | No | Case-insensitive substring match on agent name |
+| `limit` | integer | No | Max results per page (default: 20, max: 100) |
+| `offset` | integer | No | Pagination offset (default: 0) |
+
+### Response `200 OK`
+
+```json
+{
+  "agents": [
+    {
+      "agent_id": "did:hedera:testnet:z6Mk..._0.0.98765",
+      "name": "FinanceResearcher-v1",
+      "capabilities": ["payment.initiate", "market.read"],
+      "endpoint": "https://api.ainative.studio/agents/finance-researcher",
+      "registered_at": "2026-04-03T12:00:00Z"
+    }
+  ],
+  "total": 1,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agents` | object[] | Array of matching agent summaries |
+| `total` | integer | Total matching agents (for pagination) |
+| `limit` | integer | Page size used |
+| `offset` | integer | Offset used |
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 422 | `SCHEMA_VALIDATION_ERROR` | Invalid query parameters |
+| 502 | `HEDERA_NETWORK_ERROR` | Cannot read HCS-14 directory topic |

--- a/docs/api/HEDERA_REPUTATION_API.md
+++ b/docs/api/HEDERA_REPUTATION_API.md
@@ -1,0 +1,264 @@
+# Hedera Reputation API Reference
+
+Issue #195: Agent Identity Documentation — reputation API reference.
+
+Base URL: `https://api.ainative.studio/api/v1`
+
+All endpoints require `X-API-Key` or `Authorization: Bearer <jwt>` unless stated otherwise.
+
+Reputation data is anchored to Hedera Consensus Service (HCS) topics so every
+feedback submission is timestamped, ordered, and publicly verifiable.
+
+---
+
+## Endpoints
+
+- [POST /agents/{id}/feedback](#post-agentsidfeedback)
+- [GET /agents/{id}/reputation](#get-agentsidreputation)
+- [GET /agents/ranked](#get-agentsranked)
+
+---
+
+## POST /agents/{id}/feedback
+
+Submit HCS-anchored feedback for an agent interaction.
+
+The feedback message is signed by the submitting agent's private key, then
+published to the receiving agent's HCS reputation topic.  The resulting
+consensus timestamp serves as the immutable record of the feedback.
+
+### Request
+
+```
+POST /api/v1/agents/{id}/feedback
+Content-Type: application/json
+X-API-Key: <key>
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Receiving agent DID or numeric agent ID |
+
+**Body:**
+
+```json
+{
+  "rating": 5,
+  "category": "payment",
+  "comment": "Payment completed on time with correct amount.",
+  "interaction_id": "x402-req-abc123",
+  "submitter_did": "did:hedera:testnet:z6MkSubmitter..._0.0.11111"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rating` | integer | Yes | Score from 1 (poor) to 5 (excellent) |
+| `category` | string | Yes | Interaction category: `payment`, `compliance`, `memory`, `general` |
+| `comment` | string | No | Free-text feedback (max 500 chars) |
+| `interaction_id` | string | No | Reference to the specific interaction being rated |
+| `submitter_did` | string | Yes | DID of the agent submitting feedback |
+
+### Response `201 Created`
+
+```json
+{
+  "feedback_id": "hcs-msg-0.0.77777-1234567890",
+  "receiving_agent_id": "did:hedera:testnet:z6Mk..._0.0.98765",
+  "submitter_did": "did:hedera:testnet:z6MkSubmitter..._0.0.11111",
+  "rating": 5,
+  "category": "payment",
+  "hcs_topic_id": "0.0.77777",
+  "consensus_timestamp": "2026-04-03T12:05:00.123456789Z",
+  "created_at": "2026-04-03T12:05:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `feedback_id` | string | Unique feedback record identifier (topic + sequence) |
+| `receiving_agent_id` | string | DID of the agent that received the rating |
+| `submitter_did` | string | DID of the submitting agent |
+| `rating` | integer | Rating as submitted |
+| `category` | string | Category as submitted |
+| `hcs_topic_id` | string | HCS topic where the feedback message was posted |
+| `consensus_timestamp` | string | Hedera consensus timestamp (immutable proof of submission) |
+| `created_at` | string | ISO 8601 UTC wall-clock timestamp |
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 404 | `AGENT_NOT_FOUND` | No agent with the provided `id` |
+| 422 | `SCHEMA_VALIDATION_ERROR` | Missing required fields or invalid rating range |
+| 422 | `INVALID_SIGNATURE` | Submitter DID signature verification failed |
+| 502 | `HEDERA_NETWORK_ERROR` | HCS message submission failed |
+
+---
+
+## GET /agents/{id}/reputation
+
+Get the aggregated reputation score and tier for an agent.
+
+Reputation is calculated from all HCS-anchored feedback messages published to
+the agent's reputation topic.  Scores are weighted by recency and feedback
+category.
+
+### Request
+
+```
+GET /api/v1/agents/{id}/reputation
+X-API-Key: <key>
+```
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Agent DID or numeric agent ID |
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `since` | string | No | ISO 8601 timestamp; include only feedback after this date |
+| `category` | string | No | Filter by feedback category |
+
+### Response `200 OK`
+
+```json
+{
+  "agent_id": "did:hedera:testnet:z6Mk..._0.0.98765",
+  "overall_score": 4.7,
+  "tier": "gold",
+  "total_feedback": 128,
+  "score_breakdown": {
+    "payment": 4.9,
+    "compliance": 4.8,
+    "memory": 4.5,
+    "general": 4.6
+  },
+  "recent_trend": "up",
+  "last_updated": "2026-04-03T12:05:00Z",
+  "hcs_topic_id": "0.0.77777"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Agent DID |
+| `overall_score` | float | Weighted average rating (1.0–5.0) |
+| `tier` | string | Reputation tier: `bronze`, `silver`, `gold`, `platinum` |
+| `total_feedback` | integer | Total HCS-anchored feedback messages counted |
+| `score_breakdown` | object | Per-category average scores |
+| `recent_trend` | string | Score trend over last 30 days: `up`, `down`, `stable` |
+| `last_updated` | string | Timestamp of the most recent feedback included |
+| `hcs_topic_id` | string | HCS topic where feedback is anchored |
+
+### Tier thresholds
+
+| Tier | Minimum score | Minimum feedback count |
+|------|--------------|----------------------|
+| `bronze` | 1.0 | 1 |
+| `silver` | 3.5 | 10 |
+| `gold` | 4.5 | 50 |
+| `platinum` | 4.8 | 200 |
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 404 | `AGENT_NOT_FOUND` | No agent with the provided `id` |
+| 502 | `HEDERA_NETWORK_ERROR` | Cannot read HCS reputation topic |
+
+---
+
+## GET /agents/ranked
+
+Get agents ranked by reputation score, with optional capability and tier filtering.
+
+### Request
+
+```
+GET /api/v1/agents/ranked
+X-API-Key: <key>
+```
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `capabilities` | string | No | Comma-separated capability filter (e.g. `payment.initiate,market.read`) |
+| `tier` | string | No | Minimum tier: `bronze`, `silver`, `gold`, `platinum` |
+| `category` | string | No | Rank by a specific feedback category score |
+| `limit` | integer | No | Max results (default: 20, max: 100) |
+| `offset` | integer | No | Pagination offset (default: 0) |
+
+**Example:**
+
+```
+GET /api/v1/agents/ranked?capabilities=payment.initiate&tier=gold&limit=10
+```
+
+### Response `200 OK`
+
+```json
+{
+  "agents": [
+    {
+      "rank": 1,
+      "agent_id": "did:hedera:testnet:z6Mk..._0.0.98765",
+      "name": "FinanceResearcher-v1",
+      "overall_score": 4.9,
+      "tier": "platinum",
+      "total_feedback": 312,
+      "capabilities": ["payment.initiate", "market.read", "compliance.report"],
+      "endpoint": "https://api.ainative.studio/agents/finance-researcher"
+    },
+    {
+      "rank": 2,
+      "agent_id": "did:hedera:testnet:z6MkOther..._0.0.11111",
+      "name": "PaymentProcessor-v2",
+      "overall_score": 4.8,
+      "tier": "gold",
+      "total_feedback": 87,
+      "capabilities": ["payment.initiate", "payment.approve"],
+      "endpoint": "https://api.ainative.studio/agents/payment-processor"
+    }
+  ],
+  "total": 2,
+  "limit": 10,
+  "offset": 0,
+  "ranked_by": "overall_score",
+  "filters_applied": {
+    "capabilities": ["payment.initiate"],
+    "tier": "gold"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agents` | object[] | Ranked agent summaries |
+| `agents[].rank` | integer | 1-based rank position |
+| `agents[].agent_id` | string | Agent DID |
+| `agents[].name` | string | Agent name |
+| `agents[].overall_score` | float | Weighted reputation score |
+| `agents[].tier` | string | Current reputation tier |
+| `agents[].total_feedback` | integer | Total feedback count |
+| `agents[].capabilities` | string[] | AAP capability strings |
+| `agents[].endpoint` | string | Agent service endpoint |
+| `total` | integer | Total matching agents before pagination |
+| `limit` | integer | Page size used |
+| `offset` | integer | Offset used |
+| `ranked_by` | string | Score field used for ranking |
+| `filters_applied` | object | Echo of active filters |
+
+### Error responses
+
+| Status | `error_code` | When |
+|--------|-------------|------|
+| 422 | `SCHEMA_VALIDATION_ERROR` | Invalid query parameter values |
+| 502 | `HEDERA_NETWORK_ERROR` | Cannot read reputation data from HCS |

--- a/docs/development-guides/HEDERA_AGENT_IDENTITY_GUIDE.md
+++ b/docs/development-guides/HEDERA_AGENT_IDENTITY_GUIDE.md
@@ -1,0 +1,324 @@
+# Hedera Agent Identity Guide
+
+Issue #195: Agent Identity Documentation — development guide.
+
+This guide explains how Agent-402 represents each agent as a unique, verifiable
+on-chain identity using Hedera Token Service (HTS) NFTs, `did:hedera` DIDs, and
+the HCS-14 directory protocol.
+
+---
+
+## Table of Contents
+
+1. [Concepts](#1-concepts)
+2. [HTS NFT Agent Registry](#2-hts-nft-agent-registry)
+3. [did:hedera DID Integration](#3-didhedera-did-integration)
+4. [HCS-14 Directory Registration](#4-hcs-14-directory-registration)
+5. [AAP Capability Mapping](#5-aap-capability-mapping)
+6. [Example Registration Flow](#6-example-registration-flow)
+7. [Error Reference](#7-error-reference)
+
+---
+
+## 1. Concepts
+
+### Why on-chain agent identity?
+
+Agent-402 targets autonomous fintech workflows where every action must be
+auditable and non-repudiable (PRD §10).  Giving each agent a blockchain-anchored
+identity means:
+
+- **Verifiable provenance** — any payment or decision can be traced to a
+  specific agent instance.
+- **Portable reputation** — a DID-linked reputation score survives service
+  restarts or infrastructure migrations.
+- **Interoperability** — other agents and services can discover capabilities
+  via the HCS-14 open directory without a centralised registry.
+
+### Component overview
+
+| Component | Purpose |
+|-----------|---------|
+| HTS NFT | Unique, tamper-proof agent token on Hedera mainnet/testnet |
+| `did:hedera` | W3C-compliant Decentralised Identifier anchored via HCS |
+| HCS-14 directory | Topic-based agent capability advertisement |
+| AAP | Agent Ability Protocol — structured capability declarations |
+
+---
+
+## 2. HTS NFT Agent Registry
+
+### Minting an agent NFT
+
+Each agent registration mints one NFT from the shared `AGENT_REGISTRY_TOKEN_ID`
+Non-Fungible Token.  The NFT serial number becomes the agent's immutable numeric
+identifier within the registry.
+
+**NFT metadata schema (JSON, stored in IPFS / HCS topic):**
+
+```json
+{
+  "agent_id": "did:hedera:testnet:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+  "name": "FinanceResearcher-v1",
+  "version": "1.0.0",
+  "capabilities": ["payment.initiate", "market.read", "compliance.report"],
+  "created_at": "2026-04-03T00:00:00Z",
+  "owner_account": "0.0.12345"
+}
+```
+
+### Token configuration
+
+```
+Token type:        NON_FUNGIBLE_UNIQUE
+Supply type:       INFINITE
+Treasury account:  AINative operator account
+Admin key:         None (immutable after creation — PRD §10)
+KYC key:           None
+Freeze key:        None
+```
+
+Removing the admin key after initial setup guarantees that NFT metadata cannot
+be altered post-issuance, satisfying the non-repudiation requirement.
+
+---
+
+## 3. did:hedera DID Integration
+
+### DID format
+
+```
+did:hedera:<network>:<publicKeyMultibase>_<topicId>
+```
+
+Example:
+
+```
+did:hedera:testnet:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp_0.0.98765
+```
+
+- `<network>` — `mainnet` or `testnet`
+- `<publicKeyMultibase>` — base58btc-encoded Ed25519 public key
+- `<topicId>` — Hedera Consensus Service topic that anchors the DID document
+
+### DID Document fields relevant to agents
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:hedera:testnet:z6Mk..._0.0.98765",
+  "verificationMethod": [
+    {
+      "id": "did:hedera:testnet:z6Mk..._0.0.98765#key-1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:hedera:testnet:z6Mk..._0.0.98765",
+      "publicKeyMultibase": "z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+    }
+  ],
+  "authentication": ["#key-1"],
+  "service": [
+    {
+      "id": "#agent-endpoint",
+      "type": "AgentService",
+      "serviceEndpoint": "https://api.ainative.studio/agents/0.0.12345"
+    }
+  ]
+}
+```
+
+### Key management
+
+Agent private keys are generated at registration time and stored encrypted in
+the agent's ZeroDB record.  The public key is published in the DID document and
+on the HTS NFT metadata.
+
+---
+
+## 4. HCS-14 Directory Registration
+
+HCS-14 defines a Hedera Consensus Service topic used as an open agent directory.
+Any agent that submits a valid registration message to the directory topic becomes
+discoverable by other agents and orchestrators.
+
+### Directory topic
+
+The directory topic ID is configured in `backend/app/core/config.py` as
+`HEDERA_AGENT_DIRECTORY_TOPIC_ID`.
+
+### Registration message format
+
+```json
+{
+  "p": "hcs-14",
+  "op": "register",
+  "agent_id": "did:hedera:testnet:z6Mk..._0.0.98765",
+  "name": "FinanceResearcher-v1",
+  "capabilities": ["payment.initiate", "market.read"],
+  "endpoint": "https://api.ainative.studio/agents/0.0.12345",
+  "timestamp": "2026-04-03T00:00:00Z",
+  "signature": "<Ed25519 signature over canonical JSON>"
+}
+```
+
+### Message validation rules
+
+1. `p` must equal `"hcs-14"`.
+2. `op` must be one of `register`, `update`, `deregister`.
+3. `agent_id` must resolve to a valid `did:hedera` DID document.
+4. `signature` must verify against the `authentication` key in the DID document.
+5. `timestamp` must be within 5 minutes of the consensus timestamp.
+
+---
+
+## 5. AAP Capability Mapping
+
+The Agent Ability Protocol (AAP) provides a structured vocabulary for declaring
+what an agent can do.  Capabilities are expressed as dot-separated namespaced
+strings.
+
+### Standard capability namespaces
+
+| Namespace | Description |
+|-----------|-------------|
+| `payment.*` | Initiate, approve, or cancel USDC payments |
+| `market.*` | Read market data, prices, or order books |
+| `compliance.*` | Generate or submit compliance reports |
+| `memory.*` | Store or retrieve agent memory |
+| `directory.*` | Register in or query the HCS-14 directory |
+| `reputation.*` | Submit or read HCS-anchored reputation feedback |
+
+### Specific capabilities
+
+| Capability string | Description |
+|-------------------|-------------|
+| `payment.initiate` | Agent may originate a payment transaction |
+| `payment.approve` | Agent may countersign a multi-sig payment |
+| `market.read` | Agent may query price feeds and order books |
+| `compliance.report` | Agent may submit compliance event records |
+| `memory.write` | Agent may persist new memory entries |
+| `memory.read` | Agent may retrieve its own memory entries |
+
+### Capability declaration in the DID service endpoint
+
+```json
+{
+  "id": "#capabilities",
+  "type": "AAPCapabilitySet",
+  "serviceEndpoint": {
+    "capabilities": ["payment.initiate", "market.read", "compliance.report"],
+    "aap_version": "1.0"
+  }
+}
+```
+
+---
+
+## 6. Example Registration Flow
+
+The following sequence registers a new agent end-to-end.
+
+```
+Client                  Agent-402 API             Hedera Network
+  |                          |                          |
+  |-- POST /agents/register ->|                          |
+  |   { name, capabilities } |                          |
+  |                          |-- Generate Ed25519 keypair
+  |                          |-- Create HCS topic ------>|
+  |                          |<- topic_id ---------------| 0.0.98765
+  |                          |-- Mint HTS NFT ---------->|
+  |                          |<- nft_serial_number ------| 42
+  |                          |-- Publish DID document -->| (HCS message)
+  |                          |-- Submit HCS-14 register->| (directory topic)
+  |                          |-- Store agent record in ZeroDB
+  |<- 201 { agent_id, did } -|
+```
+
+### Step-by-step
+
+**Step 1 — Generate identity material**
+
+```python
+from hedera import PrivateKey
+private_key = PrivateKey.generate_ed25519()
+public_key = private_key.get_public_key()
+```
+
+**Step 2 — Create HCS topic for DID anchoring**
+
+```python
+from hedera import TopicCreateTransaction, Client
+topic_id = (
+    TopicCreateTransaction()
+    .set_topic_memo(f"DID anchor for {agent_name}")
+    .execute(client)
+    .get_receipt(client)
+    .topic_id
+)
+```
+
+**Step 3 — Mint the agent NFT**
+
+```python
+from hedera import TokenMintTransaction
+serial = (
+    TokenMintTransaction()
+    .set_token_id(AGENT_REGISTRY_TOKEN_ID)
+    .add_metadata(json.dumps(nft_metadata).encode())
+    .execute(client)
+    .get_receipt(client)
+    .serial_numbers[0]
+)
+```
+
+**Step 4 — Publish the DID document to the HCS topic**
+
+```python
+from hedera import TopicMessageSubmitTransaction
+did_document_json = json.dumps(did_document)
+TopicMessageSubmitTransaction() \
+    .set_topic_id(topic_id) \
+    .set_message(did_document_json) \
+    .execute(client)
+```
+
+**Step 5 — Register in the HCS-14 directory**
+
+```python
+import json, hashlib
+from hedera import TopicMessageSubmitTransaction
+
+registration_msg = {
+    "p": "hcs-14",
+    "op": "register",
+    "agent_id": did,
+    "name": agent_name,
+    "capabilities": capabilities,
+    "endpoint": endpoint_url,
+    "timestamp": datetime.utcnow().isoformat() + "Z",
+}
+canonical = json.dumps(registration_msg, sort_keys=True).encode()
+signature = private_key.sign(canonical).hex()
+registration_msg["signature"] = signature
+
+TopicMessageSubmitTransaction() \
+    .set_topic_id(HEDERA_AGENT_DIRECTORY_TOPIC_ID) \
+    .set_message(json.dumps(registration_msg)) \
+    .execute(client)
+```
+
+**Step 6 — Store in ZeroDB**
+
+The API persists the agent record (DID, public key, NFT serial, capabilities)
+in the `agents` ZeroDB table, which is append-only for audit integrity.
+
+---
+
+## 7. Error Reference
+
+| Error code | HTTP | Meaning |
+|------------|------|---------|
+| `AGENT_NOT_FOUND` | 404 | No agent with the given DID or ID |
+| `DUPLICATE_AGENT_DID` | 409 | Agent with this DID already registered |
+| `HEDERA_NETWORK_ERROR` | 502 | Hedera SDK call failed |
+| `INVALID_SIGNATURE` | 422 | HCS-14 message signature invalid |
+| `IMMUTABLE_RECORD` | 403 | Attempt to modify append-only agent record |


### PR DESCRIPTION
## Summary
- Per-transaction spend limit enforcement via SpendTrackingService extension
- Sliding-window rate limiter (100 req/min per DID) with FastAPI middleware
- Pydantic schemas for spend limit config and status
- Hedera agent identity developer guide and API docs for identity + reputation

## Test Evidence
```
25 passed in 0.19s
rate_limiter_service.py — 100% coverage
spend_tracking_service new methods — 100% coverage
```

## Files Changed
- `backend/app/services/spend_tracking_service.py` — added check_per_transaction_limit()
- `backend/app/core/errors.py` — added PerTransactionLimitExceededError, RateLimitExceededError
- `backend/app/services/rate_limiter_service.py` — NEW sliding-window rate limiter
- `backend/app/middleware/rate_limiter.py` — NEW FastAPI middleware
- `backend/app/schemas/spend_limits.py` — NEW Pydantic schemas
- `docs/` — 3 new documentation files

Closes #239, Closes #195