### PR TITLE
[FEATURE] Marketplace + Trustless V1 - Fixes #214, #215, #216, #217, #235, #236, #237

### DIFF
--- a/backend/app/api/marketplace.py
+++ b/backend/app/api/marketplace.py
@@ -1,0 +1,142 @@
+"""
+Marketplace API router.
+Exposes marketplace publish/browse/search/install endpoints.
+
+Issues #214–#216.
+
+Built by AINative Dev Team
+Refs #214, #215, #216
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.schemas.marketplace import (
+    BrowseAgentsResponse,
+    InstallAgentRequest,
+    InstalledAgentResponse,
+    MarketplaceAgentResponse,
+    PublishAgentRequest,
+    SearchAgentsRequest,
+    UpdateListingRequest,
+)
+from app.services.marketplace_service import (
+    MarketplaceNotFoundError,
+    marketplace_service,
+)
+
+router = APIRouter(prefix="/marketplace", tags=["marketplace"])
+
+
+@router.post("/agents", response_model=Dict[str, Any], status_code=201)
+async def publish_agent(body: PublishAgentRequest) -> Dict[str, Any]:
+    """Publish an agent configuration to the marketplace."""
+    return await marketplace_service.publish_agent(
+        agent_config=body.agent_config,
+        publisher_did=body.publisher_did,
+        pricing=body.pricing.dict(),
+        category=body.category.value,
+        description=body.description,
+        tags=body.tags,
+    )
+
+
+@router.get("/agents/{marketplace_id}", response_model=Dict[str, Any])
+async def get_agent(marketplace_id: str) -> Dict[str, Any]:
+    """Retrieve a marketplace listing by ID."""
+    try:
+        return await marketplace_service.get_published_agent(marketplace_id)
+    except MarketplaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.patch("/agents/{marketplace_id}", response_model=Dict[str, Any])
+async def update_listing(
+    marketplace_id: str, body: UpdateListingRequest
+) -> Dict[str, Any]:
+    """Update a marketplace listing's pricing/description."""
+    try:
+        updates = body.dict(exclude_none=True)
+        if "pricing" in updates:
+            updates["pricing"] = updates["pricing"]  # already a dict via pydantic
+        return await marketplace_service.update_listing(marketplace_id, updates)
+    except MarketplaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.delete("/agents/{marketplace_id}", response_model=Dict[str, Any])
+async def unpublish_agent(marketplace_id: str) -> Dict[str, Any]:
+    """Remove an agent from the marketplace."""
+    try:
+        return await marketplace_service.unpublish_agent(marketplace_id)
+    except MarketplaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/browse", response_model=Dict[str, Any])
+async def browse_agents(
+    category: Optional[str] = Query(None),
+    sort_by: str = Query("newest"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> Dict[str, Any]:
+    """Browse all marketplace listings with optional category filter."""
+    return await marketplace_service.browse_agents(
+        category=category, sort_by=sort_by, limit=limit, offset=offset
+    )
+
+
+@router.post("/search", response_model=Dict[str, Any])
+async def search_agents(body: SearchAgentsRequest) -> Dict[str, Any]:
+    """Search agents by text query and filters."""
+    filters: Dict[str, Any] = {}
+    if body.capability:
+        filters["capability"] = body.capability
+    if body.price_range:
+        filters["price_range"] = body.price_range
+    if body.min_reputation is not None:
+        filters["min_reputation"] = body.min_reputation
+    if body.category:
+        filters["category"] = body.category.value
+
+    return await marketplace_service.search_agents(query=body.query, filters=filters)
+
+
+@router.get("/categories", response_model=List[str])
+async def get_categories() -> List[str]:
+    """Return all available agent categories."""
+    return await marketplace_service.get_categories()
+
+
+@router.post("/install", response_model=Dict[str, Any], status_code=201)
+async def install_agent(body: InstallAgentRequest) -> Dict[str, Any]:
+    """Install a marketplace agent into a project."""
+    try:
+        return await marketplace_service.install_agent(
+            project_id=body.project_id,
+            marketplace_agent_id=body.marketplace_agent_id,
+        )
+    except MarketplaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/projects/{project_id}/agents", response_model=List[Dict[str, Any]])
+async def list_installed(project_id: str) -> List[Dict[str, Any]]:
+    """List all agents installed in a project."""
+    return await marketplace_service.list_installed(project_id)
+
+
+@router.delete(
+    "/projects/{project_id}/agents/{agent_id}", response_model=Dict[str, Any]
+)
+async def uninstall_agent(project_id: str, agent_id: str) -> Dict[str, Any]:
+    """Uninstall an agent from a project."""
+    try:
+        return await marketplace_service.uninstall_agent(
+            project_id=project_id, agent_id=agent_id
+        )
+    except MarketplaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/api/trustless.py
+++ b/backend/app/api/trustless.py
@@ -1,0 +1,68 @@
+"""
+Trustless Runtime API router.
+Exposes x402 service registry and execution endpoints.
+
+Issue #235.
+
+Built by AINative Dev Team
+Refs #235
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.trustless import (
+    DiscoverServicesRequest,
+    ExecuteServiceCallRequest,
+    RegisterServiceRequest,
+    ServiceCallReceipt,
+    ServiceRegistryEntry,
+)
+from app.services.trustless_runtime_service import (
+    ServiceNotFoundError,
+    trustless_runtime_service,
+)
+
+router = APIRouter(prefix="/trustless", tags=["trustless"])
+
+
+@router.post("/services", response_model=Dict[str, Any], status_code=201)
+async def register_service(body: RegisterServiceRequest) -> Dict[str, Any]:
+    """Advertise an agent service in the trustless registry."""
+    return await trustless_runtime_service.register_service(
+        agent_did=body.agent_did,
+        service_description=body.service_description,
+        pricing=body.pricing.dict(),
+        x402_endpoint=body.x402_endpoint,
+        capabilities=body.capabilities,
+    )
+
+
+@router.get("/services", response_model=List[Dict[str, Any]])
+async def get_registry() -> List[Dict[str, Any]]:
+    """Return all advertised services."""
+    return await trustless_runtime_service.get_service_registry()
+
+
+@router.post("/discover", response_model=List[Dict[str, Any]])
+async def discover_services(body: DiscoverServicesRequest) -> List[Dict[str, Any]]:
+    """Discover services by capability and optional price ceiling."""
+    return await trustless_runtime_service.discover_services(
+        capability=body.capability,
+        max_price=body.max_price,
+    )
+
+
+@router.post("/execute", response_model=Dict[str, Any], status_code=201)
+async def execute_service_call(body: ExecuteServiceCallRequest) -> Dict[str, Any]:
+    """Invoke a registered service with an x402 payment simulation."""
+    try:
+        return await trustless_runtime_service.execute_service_call(
+            caller_did=body.caller_did,
+            service_id=body.service_id,
+            payload=body.payload,
+        )
+    except ServiceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/schemas/governance.py
+++ b/backend/app/schemas/governance.py
@@ -1,0 +1,57 @@
+"""
+Governance policy API schemas.
+
+Issue #236: Agent Self-Governance Policies.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PolicyType(str, Enum):
+    """Supported governance policy types."""
+
+    SPEND_LIMIT = "spend_limit"
+    INTERACTION_WHITELIST = "interaction_whitelist"
+    TASK_SCOPE = "task_scope"
+    DATA_ACCESS = "data_access"
+
+
+class CreatePolicyRequest(BaseModel):
+    """Request body for creating a governance policy."""
+
+    agent_did: str
+    policy_type: PolicyType
+    rules: Dict[str, Any] = Field(description="Policy-type-specific rule definitions")
+
+
+class PolicyResponse(BaseModel):
+    """Response representing a governance policy."""
+
+    policy_id: str
+    agent_did: str
+    policy_type: str
+    rules: Dict[str, Any]
+    created_at: str
+    active: bool
+
+
+class EvaluatePolicyRequest(BaseModel):
+    """Request body for evaluating whether an action is permitted."""
+
+    agent_did: str
+    action: str = Field(description="Action identifier (e.g. 'spend', 'call_agent', 'read_file')")
+    context: Dict[str, Any] = Field(description="Contextual data for policy evaluation")
+
+
+class PolicyEvaluationResult(BaseModel):
+    """Result of policy evaluation."""
+
+    allowed: bool
+    agent_did: str
+    action: str
+    violated_policies: List[str] = Field(default_factory=list)
+    reason: str

--- a/backend/app/schemas/marketplace.py
+++ b/backend/app/schemas/marketplace.py
@@ -1,0 +1,117 @@
+"""
+Marketplace API schemas for request/response validation.
+
+Issues #214–#216: Agent Marketplace (publish, browse, install).
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentCategory(str, Enum):
+    """Categories for marketplace agents."""
+
+    FINANCE = "finance"
+    ANALYTICS = "analytics"
+    COMMUNICATION = "communication"
+    DEVELOPMENT = "development"
+    RESEARCH = "research"
+    AUTOMATION = "automation"
+    OTHER = "other"
+
+
+class MarketplaceSortBy(str, Enum):
+    """Sort order for marketplace browsing."""
+
+    NEWEST = "newest"
+    OLDEST = "oldest"
+    HIGHEST_RATED = "highest_rated"
+    LOWEST_PRICE = "lowest_price"
+    HIGHEST_PRICE = "highest_price"
+    MOST_INSTALLED = "most_installed"
+
+
+class PricingModel(BaseModel):
+    """Pricing configuration for a marketplace agent."""
+
+    price_per_call: float = Field(ge=0.0, description="Price in USDC per API call")
+    price_per_hour: Optional[float] = Field(None, ge=0.0, description="Price in USDC per hour")
+    free_tier_calls: int = Field(default=0, ge=0, description="Number of free calls per day")
+
+
+class PublishAgentRequest(BaseModel):
+    """Request body for publishing an agent to the marketplace."""
+
+    agent_config: Dict[str, Any] = Field(description="Agent configuration object")
+    publisher_did: str = Field(description="Publisher DID (decentralized identifier)")
+    pricing: PricingModel
+    category: AgentCategory = AgentCategory.OTHER
+    description: str = Field(default="", description="Human-readable description")
+    tags: List[str] = Field(default_factory=list)
+
+
+class UpdateListingRequest(BaseModel):
+    """Request body for updating a marketplace listing."""
+
+    pricing: Optional[PricingModel] = None
+    description: Optional[str] = None
+    tags: Optional[List[str]] = None
+    category: Optional[AgentCategory] = None
+
+
+class MarketplaceAgentResponse(BaseModel):
+    """Response representing a marketplace agent listing."""
+
+    marketplace_id: str
+    agent_id: str
+    publisher_did: str
+    pricing: Dict[str, Any]
+    category: str
+    description: str
+    tags: List[str]
+    reputation_score: float
+    install_count: int
+    created_at: str
+    updated_at: str
+
+
+class BrowseAgentsResponse(BaseModel):
+    """Paginated browse response."""
+
+    items: List[MarketplaceAgentResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class SearchAgentsRequest(BaseModel):
+    """Request body for searching agents."""
+
+    query: str = Field(description="Free-text search query")
+    capability: Optional[str] = None
+    price_range: Optional[Dict[str, float]] = Field(
+        None, description='{"min": 0.0, "max": 1.0}'
+    )
+    min_reputation: Optional[float] = Field(None, ge=0.0, le=5.0)
+    category: Optional[AgentCategory] = None
+
+
+class InstallAgentRequest(BaseModel):
+    """Request body for installing an agent into a project."""
+
+    project_id: str
+    marketplace_agent_id: str
+
+
+class InstalledAgentResponse(BaseModel):
+    """Response representing an installed agent."""
+
+    installation_id: str
+    project_id: str
+    marketplace_agent_id: str
+    agent_id: str
+    installed_at: str
+    config_snapshot: Dict[str, Any]

--- a/backend/app/schemas/trustless.py
+++ b/backend/app/schemas/trustless.py
@@ -1,0 +1,66 @@
+"""
+Trustless runtime API schemas.
+
+Issue #235: Agent Runtime with x402 Service Advertising.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ServicePricing(BaseModel):
+    """Pricing configuration for a registered service."""
+
+    price_per_call: float = Field(ge=0.0, description="Price in USDC per call")
+    currency: str = Field(default="USDC")
+
+
+class RegisterServiceRequest(BaseModel):
+    """Request body for registering an advertised service."""
+
+    agent_did: str
+    service_description: str
+    pricing: ServicePricing
+    x402_endpoint: str = Field(description="Endpoint that accepts x402 payment headers")
+    capabilities: List[str] = Field(default_factory=list)
+
+
+class ServiceRegistryEntry(BaseModel):
+    """A service registered in the trustless registry."""
+
+    service_id: str
+    agent_did: str
+    service_description: str
+    pricing: Dict[str, Any]
+    x402_endpoint: str
+    capabilities: List[str]
+    registered_at: str
+
+
+class DiscoverServicesRequest(BaseModel):
+    """Request body for discovering services by capability."""
+
+    capability: str
+    max_price: Optional[float] = Field(None, ge=0.0)
+
+
+class ExecuteServiceCallRequest(BaseModel):
+    """Request body for invoking a service via x402."""
+
+    caller_did: str
+    service_id: str
+    payload: Dict[str, Any]
+
+
+class ServiceCallReceipt(BaseModel):
+    """Receipt returned after a service call is executed."""
+
+    receipt_id: str
+    service_id: str
+    caller_did: str
+    agent_did: str
+    payment_tx: str
+    result: Dict[str, Any]
+    executed_at: str

--- a/backend/app/services/governance_policy_service.py
+++ b/backend/app/services/governance_policy_service.py
@@ -1,0 +1,269 @@
+"""
+Governance Policy Service.
+Manages agent self-governance policies and policy evaluation.
+
+Issue #236: Agent Self-Governance Policies.
+
+Supported policy types:
+- spend_limit:           daily_limit_usd, per_call_limit_usd
+- interaction_whitelist: allowed_dids
+- task_scope:            allowed_tasks
+- data_access:           allowed_tables, read_only
+
+Built by AINative Dev Team
+Refs #236
+"""
+from __future__ import annotations
+
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.services.zerodb_client import get_zerodb_client
+
+logger = logging.getLogger(__name__)
+
+GOVERNANCE_POLICIES_TABLE = "governance_policies"
+
+SUPPORTED_POLICY_TYPES = {
+    "spend_limit",
+    "interaction_whitelist",
+    "task_scope",
+    "data_access",
+}
+
+
+class GovernancePolicyService:
+    """
+    Creates, stores, and evaluates agent governance policies.
+
+    Policies are persisted in ZeroDB and evaluated in-memory during
+    agent action checks.
+    """
+
+    def __init__(self, client: Optional[Any] = None) -> None:
+        self._client = client
+
+    @property
+    def client(self) -> Any:
+        """Lazy-init ZeroDB client."""
+        if self._client is None:
+            self._client = get_zerodb_client()
+        return self._client
+
+    async def create_policy(
+        self,
+        agent_did: str,
+        policy_type: str,
+        rules: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Define a governance policy for an agent.
+
+        Args:
+            agent_did: Agent DID that owns this policy
+            policy_type: One of spend_limit, interaction_whitelist, task_scope, data_access
+            rules: Policy-type-specific rule definitions
+
+        Returns:
+            Policy dict with policy_id
+
+        Raises:
+            ValueError: If policy_type is not supported
+        """
+        if policy_type not in SUPPORTED_POLICY_TYPES:
+            raise ValueError(
+                f"Unsupported policy type '{policy_type}'. "
+                f"Supported: {sorted(SUPPORTED_POLICY_TYPES)}"
+            )
+
+        policy_id = f"pol_{uuid.uuid4().hex[:16]}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        row = {
+            "policy_id": policy_id,
+            "agent_did": agent_did,
+            "policy_type": policy_type,
+            "rules": rules,
+            "active": True,
+            "created_at": now,
+        }
+
+        await self.client.insert_row(GOVERNANCE_POLICIES_TABLE, row)
+        logger.info(
+            f"Created policy {policy_id} ({policy_type}) for agent {agent_did}"
+        )
+        return self._policy_from_row(row)
+
+    async def evaluate_policy(
+        self,
+        agent_did: str,
+        action: str,
+        context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Check whether an action is permitted under the agent's governance policies.
+
+        When no policies exist for the agent, all actions are allowed.
+        If any active policy blocks the action, the result is denied.
+
+        Args:
+            agent_did: Agent whose policies to evaluate
+            action: Action identifier (e.g. 'spend', 'call_agent', 'execute_task')
+            context: Contextual data used for rule evaluation
+
+        Returns:
+            Dict with allowed (bool), agent_did, action, violated_policies, reason
+        """
+        policies = await self.get_policies(agent_did)
+
+        if not policies:
+            return {
+                "allowed": True,
+                "agent_did": agent_did,
+                "action": action,
+                "violated_policies": [],
+                "reason": "No governance policies defined — action allowed by default",
+            }
+
+        violated: List[str] = []
+
+        for policy in policies:
+            violation = self._check_policy(policy, action, context)
+            if violation:
+                violated.append(policy["policy_id"])
+
+        allowed = len(violated) == 0
+        return {
+            "allowed": allowed,
+            "agent_did": agent_did,
+            "action": action,
+            "violated_policies": violated,
+            "reason": (
+                "All policies passed"
+                if allowed
+                else f"Violated {len(violated)} policy/policies"
+            ),
+        }
+
+    async def get_policies(self, agent_did: str) -> List[Dict[str, Any]]:
+        """
+        List all governance policies for an agent.
+
+        Args:
+            agent_did: Agent DID to look up
+
+        Returns:
+            List of policy dicts
+        """
+        result = await self.client.query_rows(
+            GOVERNANCE_POLICIES_TABLE,
+            filter={"agent_did": agent_did, "active": True},
+            limit=1_000,
+        )
+        rows = result.get("rows", [])
+        return [self._policy_from_row(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_policy(
+        self,
+        policy: Dict[str, Any],
+        action: str,
+        context: Dict[str, Any],
+    ) -> bool:
+        """
+        Evaluate a single policy against an action and context.
+
+        Returns True if the policy is VIOLATED (action denied), False if allowed.
+        """
+        policy_type = policy.get("policy_type")
+        rules = policy.get("rules") or {}
+
+        if policy_type == "spend_limit":
+            return self._check_spend_limit(rules, action, context)
+        elif policy_type == "interaction_whitelist":
+            return self._check_interaction_whitelist(rules, action, context)
+        elif policy_type == "task_scope":
+            return self._check_task_scope(rules, action, context)
+        elif policy_type == "data_access":
+            return self._check_data_access(rules, action, context)
+        return False
+
+    def _check_spend_limit(
+        self,
+        rules: Dict[str, Any],
+        action: str,
+        context: Dict[str, Any],
+    ) -> bool:
+        """Violated if action is 'spend' and amount exceeds per_call_limit_usd."""
+        if action != "spend":
+            return False
+        amount = context.get("amount_usd", 0.0)
+        per_call_limit = rules.get("per_call_limit_usd")
+        if per_call_limit is not None and amount > per_call_limit:
+            return True
+        daily_limit = rules.get("daily_limit_usd")
+        if daily_limit is not None and amount > daily_limit:
+            return True
+        return False
+
+    def _check_interaction_whitelist(
+        self,
+        rules: Dict[str, Any],
+        action: str,
+        context: Dict[str, Any],
+    ) -> bool:
+        """Violated if action is 'call_agent' and target_did is not whitelisted."""
+        if action != "call_agent":
+            return False
+        allowed_dids = rules.get("allowed_dids") or []
+        target_did = context.get("target_did", "")
+        return target_did not in allowed_dids
+
+    def _check_task_scope(
+        self,
+        rules: Dict[str, Any],
+        action: str,
+        context: Dict[str, Any],
+    ) -> bool:
+        """Violated if action is 'execute_task' and task is not in allowed_tasks."""
+        if action != "execute_task":
+            return False
+        allowed_tasks = rules.get("allowed_tasks") or []
+        task = context.get("task", "")
+        return task not in allowed_tasks
+
+    def _check_data_access(
+        self,
+        rules: Dict[str, Any],
+        action: str,
+        context: Dict[str, Any],
+    ) -> bool:
+        """Violated if action is 'read_data' or 'write_data' and table not allowed."""
+        if action not in ("read_data", "write_data"):
+            return False
+        allowed_tables = rules.get("allowed_tables") or []
+        table = context.get("table", "")
+        if table and table not in allowed_tables:
+            return True
+        if action == "write_data" and rules.get("read_only"):
+            return True
+        return False
+
+    def _policy_from_row(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a raw ZeroDB row to a clean policy dict."""
+        return {
+            "policy_id": row.get("policy_id"),
+            "agent_did": row.get("agent_did"),
+            "policy_type": row.get("policy_type"),
+            "rules": row.get("rules") or {},
+            "active": row.get("active", True),
+            "created_at": row.get("created_at", ""),
+        }
+
+
+governance_policy_service = GovernancePolicyService()

--- a/backend/app/services/marketplace_hedera_service.py
+++ b/backend/app/services/marketplace_hedera_service.py
@@ -1,0 +1,149 @@
+"""
+Marketplace Hedera Service.
+On-chain agent identity verification via Hedera HTS NFTs.
+
+Issue #217: On-Chain Agent Identity via Hedera.
+
+Convention: agent_did encodes token_id and serial as
+  did:hedera:<network>:<identifier>_<token_id>_<serial>
+  e.g. did:hedera:testnet:abc_0.0.999_1
+
+Uses hedera_hts_nft_client.py READ-ONLY (no modification to that file).
+
+Built by AINative Dev Team
+Refs #217
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from app.services.hedera_hts_nft_client import (
+    HederaHTSNFTClient,
+    HederaHTSNFTClientError,
+    get_hedera_hts_nft_client,
+)
+
+logger = logging.getLogger(__name__)
+
+# Pattern to extract token_id and serial from a DID string
+# Matches: ..._0.0.<number>_<serial> at the end of the DID
+_DID_TOKEN_PATTERN = re.compile(r"_(0\.0\.\d+)_(\d+)$")
+
+
+class MarketplaceHederaService:
+    """
+    Provides on-chain identity verification for marketplace agents.
+
+    Wraps HederaHTSNFTClient (READ-ONLY) to:
+    - Verify that an agent DID maps to an existing Hedera NFT
+    - Cross-reference marketplace IDs with on-chain NFT tokens
+    """
+
+    def __init__(self, nft_client: Optional[HederaHTSNFTClient] = None) -> None:
+        self._nft_client = nft_client
+
+    @property
+    def nft_client(self) -> HederaHTSNFTClient:
+        """Lazy-init NFT client."""
+        if self._nft_client is None:
+            self._nft_client = get_hedera_hts_nft_client()
+        return self._nft_client
+
+    async def verify_on_chain_identity(self, agent_did: str) -> Dict[str, Any]:
+        """
+        Verify that an agent DID corresponds to an existing Hedera NFT.
+
+        The DID is expected to encode the token ID and serial number in its
+        suffix, using the pattern: <prefix>_<token_id>_<serial>.
+
+        Args:
+            agent_did: Agent DID string
+
+        Returns:
+            Dict with keys: verified (bool), agent_did (str), and optionally
+            token_id, serial, account_id, error
+        """
+        match = _DID_TOKEN_PATTERN.search(agent_did)
+        if not match:
+            logger.info(
+                f"DID does not contain NFT token reference: {agent_did}"
+            )
+            return {
+                "verified": False,
+                "agent_did": agent_did,
+                "error": "DID does not encode a Hedera token_id and serial",
+            }
+
+        token_id = match.group(1)
+        serial = int(match.group(2))
+
+        try:
+            nft_info = await self.nft_client.get_nft_info(token_id, serial)
+            logger.info(
+                f"On-chain identity verified: {agent_did}, "
+                f"token={token_id}, serial={serial}"
+            )
+            return {
+                "verified": True,
+                "agent_did": agent_did,
+                "token_id": token_id,
+                "serial": serial,
+                "account_id": nft_info.get("account_id"),
+                "created_timestamp": nft_info.get("created_timestamp"),
+            }
+
+        except HederaHTSNFTClientError as exc:
+            logger.warning(
+                f"On-chain identity NOT verified for {agent_did}: {exc}"
+            )
+            return {
+                "verified": False,
+                "agent_did": agent_did,
+                "error": str(exc),
+            }
+
+    async def link_marketplace_to_nft(
+        self,
+        marketplace_id: str,
+        nft_token_id: str,
+        serial: int,
+    ) -> Dict[str, Any]:
+        """
+        Create a cross-reference record linking a marketplace ID to an NFT.
+
+        Args:
+            marketplace_id: Marketplace listing identifier
+            nft_token_id: Hedera HTS token ID (e.g. "0.0.9999")
+            serial: NFT serial number (must be >= 1)
+
+        Returns:
+            Linkage dict with marketplace_id, nft_token_id, serial, linked_at
+
+        Raises:
+            ValueError: If marketplace_id is empty or serial < 1
+        """
+        if not marketplace_id:
+            raise ValueError("marketplace_id must not be empty")
+        if serial < 1:
+            raise ValueError("serial must be a positive integer (>= 1)")
+
+        now = datetime.now(timezone.utc).isoformat()
+        linkage = {
+            "marketplace_id": marketplace_id,
+            "nft_token_id": nft_token_id,
+            "serial": serial,
+            "linked_at": now,
+        }
+        logger.info(
+            f"Linked marketplace {marketplace_id} to NFT "
+            f"{nft_token_id}#{serial}"
+        )
+        return linkage
+
+
+def get_marketplace_hedera_service() -> MarketplaceHederaService:
+    """Return a default MarketplaceHederaService instance."""
+    return MarketplaceHederaService()

--- a/backend/app/services/marketplace_service.py
+++ b/backend/app/services/marketplace_service.py
@@ -1,0 +1,465 @@
+"""
+Marketplace Service.
+Handles publishing, browsing, searching, and installing agent configurations.
+
+Issues #214 (Publish), #215 (Browse/Search), #216 (Install).
+
+Built by AINative Dev Team
+Refs #214, #215, #216
+"""
+from __future__ import annotations
+
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.errors import APIError
+from app.services.zerodb_client import get_zerodb_client
+
+logger = logging.getLogger(__name__)
+
+MARKETPLACE_LISTINGS_TABLE = "marketplace_listings"
+AGENT_INSTALLATIONS_TABLE = "agent_installations"
+
+VALID_CATEGORIES = [
+    "finance",
+    "analytics",
+    "communication",
+    "development",
+    "research",
+    "automation",
+    "other",
+]
+
+
+class MarketplaceNotFoundError(APIError):
+    """Raised when a marketplace resource is not found."""
+
+    def __init__(self, resource_id: str):
+        super().__init__(
+            status_code=404,
+            error_code="MARKETPLACE_NOT_FOUND",
+            detail=f"Marketplace resource not found: {resource_id}",
+        )
+
+
+class MarketplaceService:
+    """
+    Manages agent marketplace listings and installations.
+
+    All state is persisted to ZeroDB tables:
+    - marketplace_listings: published agent configs with pricing/metadata
+    - agent_installations: per-project install records
+    """
+
+    def __init__(self, client: Optional[Any] = None) -> None:
+        self._client = client
+
+    @property
+    def client(self) -> Any:
+        """Lazy-init ZeroDB client."""
+        if self._client is None:
+            self._client = get_zerodb_client()
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Issue #214 — Publish Agent Configurations
+    # ------------------------------------------------------------------
+
+    async def publish_agent(
+        self,
+        agent_config: Dict[str, Any],
+        publisher_did: str,
+        pricing: Dict[str, Any],
+        category: str = "other",
+        description: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Publish an agent configuration to the marketplace.
+
+        Args:
+            agent_config: Agent configuration dict
+            publisher_did: Publisher DID string
+            pricing: Pricing dict (price_per_call, etc.)
+            category: Agent category (defaults to 'other')
+            description: Human-readable description
+            tags: Optional list of tag strings
+
+        Returns:
+            Published listing dict with marketplace_id
+        """
+        marketplace_id = f"mkt_{uuid.uuid4().hex[:16]}"
+        agent_id = agent_config.get("id") or f"agent_{uuid.uuid4().hex[:12]}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        row = {
+            "marketplace_id": marketplace_id,
+            "agent_id": agent_id,
+            "publisher_did": publisher_did,
+            "pricing": pricing,
+            "category": category,
+            "description": description,
+            "tags": tags or [],
+            "reputation_score": 0.0,
+            "install_count": 0,
+            "active": True,
+            "agent_config": agent_config,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        await self.client.insert_row(MARKETPLACE_LISTINGS_TABLE, row)
+        logger.info(f"Published agent to marketplace: {marketplace_id}")
+        return self._listing_from_row(row)
+
+    async def get_published_agent(self, agent_id: str) -> Dict[str, Any]:
+        """
+        Retrieve a marketplace listing by marketplace_id.
+
+        Args:
+            agent_id: The marketplace_id of the listing
+
+        Returns:
+            Listing dict
+
+        Raises:
+            MarketplaceNotFoundError: If no listing found
+        """
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter={"marketplace_id": agent_id, "active": True},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise MarketplaceNotFoundError(agent_id)
+        return self._listing_from_row(rows[0])
+
+    async def update_listing(
+        self, agent_id: str, updates: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Update a marketplace listing.
+
+        Args:
+            agent_id: marketplace_id of the listing
+            updates: Dict of fields to update (pricing, description, tags, category)
+
+        Returns:
+            Updated listing dict
+
+        Raises:
+            MarketplaceNotFoundError: If no listing found
+        """
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter={"marketplace_id": agent_id, "active": True},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise MarketplaceNotFoundError(agent_id)
+
+        row = rows[0]
+        row_id = row.get("id") or row.get("row_id")
+        now = datetime.now(timezone.utc).isoformat()
+
+        updated_row = {**row, **updates, "updated_at": now}
+        await self.client.update_row(MARKETPLACE_LISTINGS_TABLE, row_id, updated_row)
+        logger.info(f"Updated marketplace listing: {agent_id}")
+        return self._listing_from_row(updated_row)
+
+    async def unpublish_agent(self, agent_id: str) -> Dict[str, Any]:
+        """
+        Remove an agent from the marketplace.
+
+        Args:
+            agent_id: marketplace_id to unpublish
+
+        Returns:
+            Dict with success=True
+
+        Raises:
+            MarketplaceNotFoundError: If no listing found
+        """
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter={"marketplace_id": agent_id, "active": True},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise MarketplaceNotFoundError(agent_id)
+
+        row = rows[0]
+        row_id = row.get("id") or row.get("row_id")
+        now = datetime.now(timezone.utc).isoformat()
+
+        await self.client.update_row(
+            MARKETPLACE_LISTINGS_TABLE,
+            row_id,
+            {**row, "active": False, "updated_at": now},
+        )
+        logger.info(f"Unpublished agent: {agent_id}")
+        return {"success": True, "marketplace_id": agent_id}
+
+    # ------------------------------------------------------------------
+    # Issue #215 — Browse and Search Agents
+    # ------------------------------------------------------------------
+
+    async def browse_agents(
+        self,
+        category: Optional[str],
+        sort_by: str,
+        limit: int,
+        offset: int,
+    ) -> Dict[str, Any]:
+        """
+        Return a paginated list of active marketplace listings.
+
+        Args:
+            category: Optional category filter
+            sort_by: Sort key (newest, highest_rated, etc.)
+            limit: Page size
+            offset: Page offset
+
+        Returns:
+            Dict with items, total, limit, offset
+        """
+        query_filter: Dict[str, Any] = {"active": True}
+        if category:
+            query_filter["category"] = category
+
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter=query_filter,
+            limit=10_000,
+        )
+        all_rows = result.get("rows", [])
+
+        # Sort
+        if sort_by == "newest":
+            all_rows.sort(key=lambda r: r.get("created_at", ""), reverse=True)
+        elif sort_by == "oldest":
+            all_rows.sort(key=lambda r: r.get("created_at", ""))
+        elif sort_by == "highest_rated":
+            all_rows.sort(key=lambda r: r.get("reputation_score", 0.0), reverse=True)
+        elif sort_by == "lowest_price":
+            all_rows.sort(
+                key=lambda r: (r.get("pricing") or {}).get("price_per_call", 0.0)
+            )
+        elif sort_by == "highest_price":
+            all_rows.sort(
+                key=lambda r: (r.get("pricing") or {}).get("price_per_call", 0.0),
+                reverse=True,
+            )
+        elif sort_by == "most_installed":
+            all_rows.sort(key=lambda r: r.get("install_count", 0), reverse=True)
+
+        total = len(all_rows)
+        page = all_rows[offset : offset + limit]
+
+        return {
+            "items": [self._listing_from_row(r) for r in page],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    async def search_agents(
+        self,
+        query: str,
+        filters: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Search marketplace listings by text query and optional filters.
+
+        Args:
+            query: Free-text search string (matched against name/description)
+            filters: Dict with optional keys: capability, price_range, min_reputation, category
+
+        Returns:
+            Dict with items list
+        """
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter={"active": True},
+            limit=10_000,
+        )
+        rows = result.get("rows", [])
+
+        query_lower = query.lower()
+
+        def _matches(row: Dict[str, Any]) -> bool:
+            name = (row.get("agent_config") or {}).get("name", "").lower()
+            description = (row.get("description") or "").lower()
+            if query_lower and query_lower not in name and query_lower not in description:
+                return False
+
+            # min_reputation filter
+            min_rep = filters.get("min_reputation")
+            if min_rep is not None:
+                if row.get("reputation_score", 0.0) < min_rep:
+                    return False
+
+            # price_range filter
+            price_range = filters.get("price_range")
+            if price_range:
+                price = (row.get("pricing") or {}).get("price_per_call", 0.0)
+                if price_range.get("min") is not None and price < price_range["min"]:
+                    return False
+                if price_range.get("max") is not None and price > price_range["max"]:
+                    return False
+
+            # category filter
+            if filters.get("category"):
+                if row.get("category") != filters["category"]:
+                    return False
+
+            return True
+
+        matched = [r for r in rows if _matches(r)]
+        return {"items": [self._listing_from_row(r) for r in matched], "total": len(matched)}
+
+    async def get_categories(self) -> List[str]:
+        """
+        Return the list of available agent categories.
+
+        Returns:
+            List of category name strings
+        """
+        return list(VALID_CATEGORIES)
+
+    # ------------------------------------------------------------------
+    # Issue #216 — Install Agent into Project
+    # ------------------------------------------------------------------
+
+    async def install_agent(
+        self,
+        project_id: str,
+        marketplace_agent_id: str,
+    ) -> Dict[str, Any]:
+        """
+        Clone an agent config into a project.
+
+        Args:
+            project_id: Target project identifier
+            marketplace_agent_id: Source marketplace listing ID
+
+        Returns:
+            Installation record dict
+
+        Raises:
+            MarketplaceNotFoundError: If marketplace listing not found
+        """
+        listing = await self.get_published_agent(marketplace_agent_id)
+
+        installation_id = f"install_{uuid.uuid4().hex[:16]}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        row = {
+            "installation_id": installation_id,
+            "project_id": project_id,
+            "marketplace_agent_id": marketplace_agent_id,
+            "agent_id": listing["agent_id"],
+            "config_snapshot": listing.get("agent_config") or {},
+            "installed_at": now,
+        }
+
+        await self.client.insert_row(AGENT_INSTALLATIONS_TABLE, row)
+
+        # Increment install_count on the listing
+        result = await self.client.query_rows(
+            MARKETPLACE_LISTINGS_TABLE,
+            filter={"marketplace_id": marketplace_agent_id},
+            limit=1,
+        )
+        listing_rows = result.get("rows", [])
+        if listing_rows:
+            listing_row = listing_rows[0]
+            row_id = listing_row.get("id") or listing_row.get("row_id")
+            updated = {
+                **listing_row,
+                "install_count": listing_row.get("install_count", 0) + 1,
+            }
+            await self.client.update_row(MARKETPLACE_LISTINGS_TABLE, row_id, updated)
+
+        logger.info(
+            f"Installed agent {marketplace_agent_id} into project {project_id}"
+        )
+        return row
+
+    async def list_installed(self, project_id: str) -> List[Dict[str, Any]]:
+        """
+        List all agents installed in a project.
+
+        Args:
+            project_id: Project identifier
+
+        Returns:
+            List of installation record dicts
+        """
+        result = await self.client.query_rows(
+            AGENT_INSTALLATIONS_TABLE,
+            filter={"project_id": project_id},
+            limit=1_000,
+        )
+        return result.get("rows", [])
+
+    async def uninstall_agent(
+        self, project_id: str, agent_id: str
+    ) -> Dict[str, Any]:
+        """
+        Remove an agent installation from a project.
+
+        Args:
+            project_id: Project identifier
+            agent_id: installation_id to remove
+
+        Returns:
+            Dict with success=True
+
+        Raises:
+            MarketplaceNotFoundError: If installation not found
+        """
+        result = await self.client.query_rows(
+            AGENT_INSTALLATIONS_TABLE,
+            filter={"project_id": project_id, "installation_id": agent_id},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise MarketplaceNotFoundError(agent_id)
+
+        row = rows[0]
+        row_id = row.get("id") or row.get("row_id")
+        await self.client.delete_row(AGENT_INSTALLATIONS_TABLE, row_id)
+        logger.info(f"Uninstalled agent {agent_id} from project {project_id}")
+        return {"success": True, "installation_id": agent_id}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _listing_from_row(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a raw ZeroDB row to a clean listing dict."""
+        return {
+            "marketplace_id": row.get("marketplace_id"),
+            "agent_id": row.get("agent_id"),
+            "publisher_did": row.get("publisher_did"),
+            "pricing": row.get("pricing") or {},
+            "category": row.get("category", "other"),
+            "description": row.get("description", ""),
+            "tags": row.get("tags") or [],
+            "reputation_score": row.get("reputation_score", 0.0),
+            "install_count": row.get("install_count", 0),
+            "active": row.get("active", True),
+            "agent_config": row.get("agent_config") or {},
+            "created_at": row.get("created_at", ""),
+            "updated_at": row.get("updated_at", ""),
+        }
+
+
+marketplace_service = MarketplaceService()

--- a/backend/app/services/trustless_runtime_service.py
+++ b/backend/app/services/trustless_runtime_service.py
@@ -1,0 +1,217 @@
+"""
+Trustless Runtime Service.
+Handles x402 service advertising, discovery, invocation, and receipts.
+
+Issue #235: Agent Runtime with x402 Service Advertising.
+
+Built by AINative Dev Team
+Refs #235
+"""
+from __future__ import annotations
+
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.errors import APIError
+from app.services.zerodb_client import get_zerodb_client
+
+logger = logging.getLogger(__name__)
+
+SERVICE_REGISTRY_TABLE = "service_registry"
+SERVICE_RECEIPTS_TABLE = "service_receipts"
+
+
+class ServiceNotFoundError(APIError):
+    """Raised when a registered service cannot be found."""
+
+    def __init__(self, service_id: str):
+        super().__init__(
+            status_code=404,
+            error_code="SERVICE_NOT_FOUND",
+            detail=f"Service not found: {service_id}",
+        )
+
+
+class TrustlessRuntimeService:
+    """
+    Manages the trustless agent service registry and x402-signed invocations.
+
+    Provides:
+    - Service registration with x402 endpoint advertising
+    - Capability-based discovery with price filtering
+    - x402-signed service execution with receipt generation
+    - Full registry enumeration
+    """
+
+    def __init__(self, client: Optional[Any] = None) -> None:
+        self._client = client
+
+    @property
+    def client(self) -> Any:
+        """Lazy-init ZeroDB client."""
+        if self._client is None:
+            self._client = get_zerodb_client()
+        return self._client
+
+    async def register_service(
+        self,
+        agent_did: str,
+        service_description: str,
+        pricing: Dict[str, Any],
+        x402_endpoint: str,
+        capabilities: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Advertise an agent service in the trustless registry.
+
+        Args:
+            agent_did: Provider agent DID
+            service_description: Human-readable service description
+            pricing: Pricing dict (price_per_call, currency, etc.)
+            x402_endpoint: URL that accepts x402 payment headers
+            capabilities: Optional list of capability tags
+
+        Returns:
+            Registry entry dict with service_id
+        """
+        service_id = f"svc_{uuid.uuid4().hex[:16]}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        row = {
+            "service_id": service_id,
+            "agent_did": agent_did,
+            "service_description": service_description,
+            "pricing": pricing,
+            "x402_endpoint": x402_endpoint,
+            "capabilities": capabilities or [],
+            "active": True,
+            "registered_at": now,
+        }
+
+        await self.client.insert_row(SERVICE_REGISTRY_TABLE, row)
+        logger.info(f"Registered service: {service_id} for agent {agent_did}")
+        return self._entry_from_row(row)
+
+    async def discover_services(
+        self,
+        capability: str,
+        max_price: Optional[float],
+    ) -> List[Dict[str, Any]]:
+        """
+        Find services that offer a given capability within a price ceiling.
+
+        Args:
+            capability: Capability string to search for
+            max_price: Optional maximum price_per_call (inclusive)
+
+        Returns:
+            List of matching registry entry dicts
+        """
+        result = await self.client.query_rows(
+            SERVICE_REGISTRY_TABLE,
+            filter={"active": True},
+            limit=10_000,
+        )
+        rows = result.get("rows", [])
+
+        def _matches(row: Dict[str, Any]) -> bool:
+            caps = row.get("capabilities") or []
+            if capability not in caps:
+                return False
+            if max_price is not None:
+                price = (row.get("pricing") or {}).get("price_per_call", 0.0)
+                if price > max_price:
+                    return False
+            return True
+
+        matched = [r for r in rows if _matches(r)]
+        return [self._entry_from_row(r) for r in matched]
+
+    async def execute_service_call(
+        self,
+        caller_did: str,
+        service_id: str,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Invoke a registered service with an x402-signed payment.
+
+        Args:
+            caller_did: Calling agent's DID
+            service_id: Target service ID
+            payload: Request payload
+
+        Returns:
+            Receipt dict with receipt_id, payment_tx, result, executed_at
+
+        Raises:
+            ServiceNotFoundError: If service_id does not exist
+        """
+        result = await self.client.query_rows(
+            SERVICE_REGISTRY_TABLE,
+            filter={"service_id": service_id, "active": True},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            raise ServiceNotFoundError(service_id)
+
+        service_row = rows[0]
+        receipt_id = f"rcpt_{uuid.uuid4().hex[:16]}"
+        payment_tx = f"tx_{uuid.uuid4().hex[:20]}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Simulated execution result (in production: HTTP call to x402_endpoint)
+        execution_result = {
+            "status": "success",
+            "payload_echo": payload,
+        }
+
+        receipt_row = {
+            "receipt_id": receipt_id,
+            "service_id": service_id,
+            "caller_did": caller_did,
+            "agent_did": service_row.get("agent_did"),
+            "payment_tx": payment_tx,
+            "result": execution_result,
+            "executed_at": now,
+        }
+
+        await self.client.insert_row(SERVICE_RECEIPTS_TABLE, receipt_row)
+        logger.info(
+            f"Executed service call: service={service_id}, caller={caller_did}, "
+            f"receipt={receipt_id}"
+        )
+        return receipt_row
+
+    async def get_service_registry(self) -> List[Dict[str, Any]]:
+        """
+        Return all advertised services.
+
+        Returns:
+            List of all active registry entry dicts
+        """
+        result = await self.client.query_rows(
+            SERVICE_REGISTRY_TABLE,
+            filter={"active": True},
+            limit=10_000,
+        )
+        rows = result.get("rows", [])
+        return [self._entry_from_row(r) for r in rows]
+
+    def _entry_from_row(self, row: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert a raw ZeroDB row to a clean registry entry dict."""
+        return {
+            "service_id": row.get("service_id"),
+            "agent_did": row.get("agent_did"),
+            "service_description": row.get("service_description", ""),
+            "pricing": row.get("pricing") or {},
+            "x402_endpoint": row.get("x402_endpoint", ""),
+            "capabilities": row.get("capabilities") or [],
+            "registered_at": row.get("registered_at", ""),
+        }
+
+
+trustless_runtime_service = TrustlessRuntimeService()

--- a/backend/app/tests/test_governance_policy_service.py
+++ b/backend/app/tests/test_governance_policy_service.py
@@ -1,0 +1,301 @@
+"""
+Tests for GovernancePolicyService.
+Issue #236: Agent Self-Governance Policies.
+
+TDD: RED phase — tests written before implementation.
+BDD-style: class Describe* / def it_*
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class DescribeGovernancePolicyServiceInit:
+    """GovernancePolicyService initializes correctly."""
+
+    def it_initializes_with_lazy_client(self):
+        """Service defers client creation."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService()
+        assert svc._client is None
+
+    def it_accepts_injected_client(self):
+        """Service accepts a pre-built client."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        mock = MagicMock()
+        svc = GovernancePolicyService(client=mock)
+        assert svc.client is mock
+
+
+class DescribeCreatePolicy:
+    """Tests for create_policy — Issue #236."""
+
+    @pytest.mark.asyncio
+    async def it_creates_spend_limit_policy(self, mock_zerodb_client):
+        """create_policy stores a spend_limit policy and returns policy_id."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 10.0, "per_call_limit_usd": 1.0},
+        )
+
+        assert "policy_id" in result
+        assert result["agent_did"] == "did:hedera:testnet:agent1"
+        assert result["policy_type"] == "spend_limit"
+        assert result["rules"]["daily_limit_usd"] == 10.0
+
+    @pytest.mark.asyncio
+    async def it_creates_interaction_whitelist_policy(self, mock_zerodb_client):
+        """create_policy stores an interaction_whitelist policy."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="interaction_whitelist",
+            rules={"allowed_dids": ["did:hedera:testnet:trusted1"]},
+        )
+
+        assert result["policy_type"] == "interaction_whitelist"
+
+    @pytest.mark.asyncio
+    async def it_creates_task_scope_policy(self, mock_zerodb_client):
+        """create_policy stores a task_scope policy."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="task_scope",
+            rules={"allowed_tasks": ["summarize", "translate"]},
+        )
+
+        assert result["policy_type"] == "task_scope"
+
+    @pytest.mark.asyncio
+    async def it_creates_data_access_policy(self, mock_zerodb_client):
+        """create_policy stores a data_access policy."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="data_access",
+            rules={"allowed_tables": ["public_data"], "read_only": True},
+        )
+
+        assert result["policy_type"] == "data_access"
+
+    @pytest.mark.asyncio
+    async def it_raises_for_unsupported_policy_type(self, mock_zerodb_client):
+        """create_policy raises ValueError for unrecognised policy type."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+
+        with pytest.raises(ValueError):
+            await svc.create_policy(
+                agent_did="did:hedera:testnet:agent1",
+                policy_type="unknown_policy",
+                rules={},
+            )
+
+    @pytest.mark.asyncio
+    async def it_persists_policy_to_governance_policies_table(self, mock_zerodb_client):
+        """create_policy inserts one row into governance_policies table."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 5.0},
+        )
+
+        rows = mock_zerodb_client.get_table_data("governance_policies")
+        assert len(rows) == 1
+
+
+class DescribeEvaluatePolicy:
+    """Tests for evaluate_policy — Issue #236."""
+
+    @pytest.mark.asyncio
+    async def it_allows_action_within_spend_limit(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=True when spend is under limit."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 10.0, "per_call_limit_usd": 1.0},
+        )
+
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:agent1",
+            action="spend",
+            context={"amount_usd": 0.5},
+        )
+
+        assert result["allowed"] is True
+        assert result["violated_policies"] == []
+
+    @pytest.mark.asyncio
+    async def it_blocks_action_exceeding_spend_limit(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=False when spend exceeds per_call_limit."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 10.0, "per_call_limit_usd": 0.10},
+        )
+
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:agent1",
+            action="spend",
+            context={"amount_usd": 5.0},
+        )
+
+        assert result["allowed"] is False
+        assert len(result["violated_policies"]) > 0
+
+    @pytest.mark.asyncio
+    async def it_allows_interaction_with_whitelisted_did(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=True when target_did is whitelisted."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        trusted = "did:hedera:testnet:trusted1"
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="interaction_whitelist",
+            rules={"allowed_dids": [trusted]},
+        )
+
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:agent1",
+            action="call_agent",
+            context={"target_did": trusted},
+        )
+
+        assert result["allowed"] is True
+
+    @pytest.mark.asyncio
+    async def it_blocks_interaction_with_non_whitelisted_did(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=False for non-whitelisted DID."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent1",
+            policy_type="interaction_whitelist",
+            rules={"allowed_dids": ["did:hedera:testnet:trusted1"]},
+        )
+
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:agent1",
+            action="call_agent",
+            context={"target_did": "did:hedera:testnet:stranger"},
+        )
+
+        assert result["allowed"] is False
+
+    @pytest.mark.asyncio
+    async def it_allows_all_actions_when_no_policies_exist(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=True when agent has no policies."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:no_policies",
+            action="spend",
+            context={"amount_usd": 999.0},
+        )
+
+        assert result["allowed"] is True
+
+    @pytest.mark.asyncio
+    async def it_blocks_out_of_scope_task(self, mock_zerodb_client):
+        """evaluate_policy returns allowed=False for tasks outside task_scope."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:scoped",
+            policy_type="task_scope",
+            rules={"allowed_tasks": ["summarize"]},
+        )
+
+        result = await svc.evaluate_policy(
+            agent_did="did:hedera:testnet:scoped",
+            action="execute_task",
+            context={"task": "delete_database"},
+        )
+
+        assert result["allowed"] is False
+
+
+class DescribeGetPolicies:
+    """Tests for get_policies — Issue #236."""
+
+    @pytest.mark.asyncio
+    async def it_returns_all_policies_for_agent(self, mock_zerodb_client):
+        """get_policies returns every policy registered for an agent_did."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:multi",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 5.0},
+        )
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:multi",
+            policy_type="task_scope",
+            rules={"allowed_tasks": ["read"]},
+        )
+
+        policies = await svc.get_policies("did:hedera:testnet:multi")
+
+        assert len(policies) == 2
+        types = {p["policy_type"] for p in policies}
+        assert "spend_limit" in types
+        assert "task_scope" in types
+
+    @pytest.mark.asyncio
+    async def it_returns_empty_list_for_agent_without_policies(
+        self, mock_zerodb_client
+    ):
+        """get_policies returns [] when no policies exist for agent."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        result = await svc.get_policies("did:hedera:testnet:nobody")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def it_does_not_return_policies_for_other_agents(self, mock_zerodb_client):
+        """get_policies scopes results to the requested agent_did only."""
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        svc = GovernancePolicyService(client=mock_zerodb_client)
+        await svc.create_policy(
+            agent_did="did:hedera:testnet:agent_A",
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 5.0},
+        )
+
+        result = await svc.get_policies("did:hedera:testnet:agent_B")
+
+        assert result == []

--- a/backend/app/tests/test_marketplace_hedera_service.py
+++ b/backend/app/tests/test_marketplace_hedera_service.py
@@ -1,0 +1,135 @@
+"""
+Tests for MarketplaceHederaService.
+Issue #217: On-Chain Agent Identity via Hedera.
+
+TDD: RED phase — tests written before implementation.
+BDD-style: class Describe* / def it_*
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class DescribeMarketplaceHederaServiceInit:
+    """MarketplaceHederaService initializes correctly."""
+
+    def it_initializes_with_lazy_nft_client(self):
+        """Service defers HederaHTSNFTClient construction."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        svc = MarketplaceHederaService()
+        assert svc._nft_client is None
+
+    def it_accepts_injected_nft_client(self):
+        """Service accepts injected client for tests."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        mock = MagicMock()
+        svc = MarketplaceHederaService(nft_client=mock)
+        assert svc.nft_client is mock
+
+
+class DescribeVerifyOnChainIdentity:
+    """Tests for verify_on_chain_identity — Issue #217."""
+
+    @pytest.mark.asyncio
+    async def it_returns_verified_true_when_nft_exists(self):
+        """verify_on_chain_identity returns verified=True if NFT is found."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        mock_nft = AsyncMock()
+        mock_nft.get_nft_info = AsyncMock(
+            return_value={
+                "token_id": "0.0.999",
+                "serial_number": 1,
+                "metadata": "eyJhZ2VudF9kaWQiOiAiZGlkOmhlZGVyYTp0ZXN0bmV0OmFiYyJ9",
+                "account_id": "0.0.111",
+            }
+        )
+
+        svc = MarketplaceHederaService(nft_client=mock_nft)
+        result = await svc.verify_on_chain_identity("did:hedera:testnet:abc_0.0.999_1")
+
+        assert result["verified"] is True
+        assert result["agent_did"] == "did:hedera:testnet:abc_0.0.999_1"
+
+    @pytest.mark.asyncio
+    async def it_returns_verified_false_when_nft_not_found(self):
+        """verify_on_chain_identity returns verified=False if NFT raises 404."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+        from app.services.hedera_hts_nft_client import HederaHTSNFTClientError
+
+        mock_nft = AsyncMock()
+        mock_nft.get_nft_info = AsyncMock(
+            side_effect=HederaHTSNFTClientError("NFT not found", 404)
+        )
+
+        svc = MarketplaceHederaService(nft_client=mock_nft)
+        result = await svc.verify_on_chain_identity("did:hedera:testnet:xyz_0.0.111_99")
+
+        assert result["verified"] is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def it_handles_did_without_token_reference(self):
+        """verify_on_chain_identity returns unverifiable for DIDs without NFT token."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        svc = MarketplaceHederaService(nft_client=AsyncMock())
+        result = await svc.verify_on_chain_identity("did:hedera:testnet:no_token_here")
+
+        # DID does not contain token_id+serial — cannot verify on-chain
+        assert result["verified"] is False
+        assert result["agent_did"] == "did:hedera:testnet:no_token_here"
+
+
+class DescribeLinkMarketplaceToNFT:
+    """Tests for link_marketplace_to_nft — Issue #217."""
+
+    @pytest.mark.asyncio
+    async def it_returns_linkage_record_with_all_ids(self):
+        """link_marketplace_to_nft creates a cross-reference record."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        svc = MarketplaceHederaService(nft_client=AsyncMock())
+        result = await svc.link_marketplace_to_nft(
+            marketplace_id="mkt_001",
+            nft_token_id="0.0.9999",
+            serial=42,
+        )
+
+        assert result["marketplace_id"] == "mkt_001"
+        assert result["nft_token_id"] == "0.0.9999"
+        assert result["serial"] == 42
+        assert "linked_at" in result
+
+    @pytest.mark.asyncio
+    async def it_raises_for_empty_marketplace_id(self):
+        """link_marketplace_to_nft raises ValueError for empty marketplace_id."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        svc = MarketplaceHederaService(nft_client=AsyncMock())
+
+        with pytest.raises(ValueError):
+            await svc.link_marketplace_to_nft(
+                marketplace_id="",
+                nft_token_id="0.0.9999",
+                serial=1,
+            )
+
+    @pytest.mark.asyncio
+    async def it_raises_for_invalid_serial(self):
+        """link_marketplace_to_nft raises ValueError for non-positive serial."""
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        svc = MarketplaceHederaService(nft_client=AsyncMock())
+
+        with pytest.raises(ValueError):
+            await svc.link_marketplace_to_nft(
+                marketplace_id="mkt_001",
+                nft_token_id="0.0.9999",
+                serial=0,
+            )

--- a/backend/app/tests/test_marketplace_service.py
+++ b/backend/app/tests/test_marketplace_service.py
@@ -1,0 +1,557 @@
+"""
+Tests for MarketplaceService.
+Issues #214 (Publish), #215 (Browse/Search), #216 (Install).
+
+TDD Approach: Tests written FIRST, then implementation — Red-Green-Refactor.
+BDD-style: class Describe* / def it_*
+
+Coverage targets:
+- publish_agent / get_published_agent / update_listing / unpublish_agent
+- browse_agents / search_agents / get_categories
+- install_agent / list_installed / uninstall_agent
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Issue #214 — Publish Agent Configurations
+# ---------------------------------------------------------------------------
+
+
+class DescribeMarketplaceServiceInit:
+    """MarketplaceService initializes correctly."""
+
+    def it_initializes_with_lazy_zerodb_client(self):
+        """Service starts with no client; client is created on first use."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService()
+        assert svc._client is None
+
+    def it_accepts_injected_client(self):
+        """Service accepts a pre-built client for test isolation."""
+        from app.services.marketplace_service import MarketplaceService
+
+        mock = MagicMock()
+        svc = MarketplaceService(client=mock)
+        assert svc.client is mock
+
+
+class DescribePublishAgent:
+    """Tests for publish_agent — Issue #214."""
+
+    @pytest.mark.asyncio
+    async def it_publishes_agent_and_returns_listing(self, mock_zerodb_client):
+        """publish_agent stores the listing and returns a dict with marketplace_id."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        agent_config = {"name": "FinanceBot", "model": "gpt-4"}
+        pricing = {"price_per_call": 0.01, "free_tier_calls": 10}
+
+        result = await svc.publish_agent(
+            agent_config=agent_config,
+            publisher_did="did:hedera:testnet:pub1",
+            pricing=pricing,
+        )
+
+        assert "marketplace_id" in result
+        assert result["publisher_did"] == "did:hedera:testnet:pub1"
+        assert result["pricing"] == pricing
+
+    @pytest.mark.asyncio
+    async def it_stores_listing_in_zerodb(self, mock_zerodb_client):
+        """publish_agent inserts exactly one row into the marketplace_listings table."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        await svc.publish_agent(
+            agent_config={"name": "Bot"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.05},
+        )
+
+        rows = mock_zerodb_client.get_table_data("marketplace_listings")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def it_generates_unique_marketplace_ids(self, mock_zerodb_client):
+        """Two publish_agent calls yield different marketplace_ids."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        r1 = await svc.publish_agent(
+            agent_config={"name": "BotA"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        r2 = await svc.publish_agent(
+            agent_config={"name": "BotB"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.02},
+        )
+
+        assert r1["marketplace_id"] != r2["marketplace_id"]
+
+
+class DescribeGetPublishedAgent:
+    """Tests for get_published_agent — Issue #214."""
+
+    @pytest.mark.asyncio
+    async def it_returns_listing_by_marketplace_id(self, mock_zerodb_client):
+        """get_published_agent retrieves a previously published listing."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        published = await svc.publish_agent(
+            agent_config={"name": "BotX"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        mid = published["marketplace_id"]
+
+        fetched = await svc.get_published_agent(mid)
+
+        assert fetched["marketplace_id"] == mid
+        assert fetched["publisher_did"] == "did:hedera:testnet:pub1"
+
+    @pytest.mark.asyncio
+    async def it_raises_not_found_for_unknown_id(self, mock_zerodb_client):
+        """get_published_agent raises MarketplaceNotFoundError for missing id."""
+        from app.services.marketplace_service import (
+            MarketplaceService,
+            MarketplaceNotFoundError,
+        )
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+
+        with pytest.raises(MarketplaceNotFoundError):
+            await svc.get_published_agent("nonexistent_id")
+
+
+class DescribeUpdateListing:
+    """Tests for update_listing — Issue #214."""
+
+    @pytest.mark.asyncio
+    async def it_updates_pricing_on_existing_listing(self, mock_zerodb_client):
+        """update_listing changes pricing and returns the updated record."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        published = await svc.publish_agent(
+            agent_config={"name": "BotY"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        mid = published["marketplace_id"]
+
+        updated = await svc.update_listing(
+            mid, {"pricing": {"price_per_call": 0.05}}
+        )
+
+        assert updated["pricing"]["price_per_call"] == 0.05
+
+    @pytest.mark.asyncio
+    async def it_raises_not_found_for_unknown_id(self, mock_zerodb_client):
+        """update_listing raises MarketplaceNotFoundError for missing id."""
+        from app.services.marketplace_service import (
+            MarketplaceService,
+            MarketplaceNotFoundError,
+        )
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+
+        with pytest.raises(MarketplaceNotFoundError):
+            await svc.update_listing("nope", {"pricing": {}})
+
+
+class DescribeUnpublishAgent:
+    """Tests for unpublish_agent — Issue #214."""
+
+    @pytest.mark.asyncio
+    async def it_removes_listing_from_marketplace(self, mock_zerodb_client):
+        """unpublish_agent deletes the row and returns success."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        published = await svc.publish_agent(
+            agent_config={"name": "BotZ"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        mid = published["marketplace_id"]
+
+        result = await svc.unpublish_agent(mid)
+
+        assert result["success"] is True
+        rows = mock_zerodb_client.get_table_data("marketplace_listings")
+        assert all(r.get("marketplace_id") != mid for r in rows)
+
+    @pytest.mark.asyncio
+    async def it_raises_not_found_when_already_unpublished(self, mock_zerodb_client):
+        """unpublish_agent raises MarketplaceNotFoundError for unknown id."""
+        from app.services.marketplace_service import (
+            MarketplaceService,
+            MarketplaceNotFoundError,
+        )
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+
+        with pytest.raises(MarketplaceNotFoundError):
+            await svc.unpublish_agent("ghost_id")
+
+
+# ---------------------------------------------------------------------------
+# Issue #215 — Browse and Search Agents
+# ---------------------------------------------------------------------------
+
+
+class DescribeBrowseAgents:
+    """Tests for browse_agents — Issue #215."""
+
+    @pytest.mark.asyncio
+    async def it_returns_all_published_agents_when_no_category(
+        self, mock_zerodb_client
+    ):
+        """browse_agents returns all listings when category is None."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        for i in range(3):
+            await svc.publish_agent(
+                agent_config={"name": f"Bot{i}"},
+                publisher_did="did:hedera:testnet:pub1",
+                pricing={"price_per_call": 0.01 * (i + 1)},
+            )
+
+        result = await svc.browse_agents(
+            category=None, sort_by="newest", limit=10, offset=0
+        )
+
+        assert result["total"] == 3
+        assert len(result["items"]) == 3
+
+    @pytest.mark.asyncio
+    async def it_respects_pagination_limit_and_offset(self, mock_zerodb_client):
+        """browse_agents returns correct page based on limit/offset."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        for i in range(5):
+            await svc.publish_agent(
+                agent_config={"name": f"Bot{i}"},
+                publisher_did="did:hedera:testnet:pub1",
+                pricing={"price_per_call": 0.01},
+            )
+
+        page1 = await svc.browse_agents(category=None, sort_by="newest", limit=2, offset=0)
+        page2 = await svc.browse_agents(category=None, sort_by="newest", limit=2, offset=2)
+
+        assert len(page1["items"]) == 2
+        assert len(page2["items"]) == 2
+        ids1 = {a["marketplace_id"] for a in page1["items"]}
+        ids2 = {a["marketplace_id"] for a in page2["items"]}
+        assert ids1.isdisjoint(ids2)
+
+    @pytest.mark.asyncio
+    async def it_filters_by_category(self, mock_zerodb_client):
+        """browse_agents filters results by category."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        await svc.publish_agent(
+            agent_config={"name": "FinBot"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+            category="finance",
+        )
+        await svc.publish_agent(
+            agent_config={"name": "DevBot"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.02},
+            category="development",
+        )
+
+        result = await svc.browse_agents(
+            category="finance", sort_by="newest", limit=10, offset=0
+        )
+
+        assert result["total"] == 1
+        assert result["items"][0]["category"] == "finance"
+
+
+class DescribeSearchAgents:
+    """Tests for search_agents — Issue #215."""
+
+    @pytest.mark.asyncio
+    async def it_returns_results_matching_query(self, mock_zerodb_client):
+        """search_agents returns listings whose description matches query."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        await svc.publish_agent(
+            agent_config={"name": "PaymentBot"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+            description="Handles payment processing and invoicing",
+        )
+        await svc.publish_agent(
+            agent_config={"name": "WeatherBot"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+            description="Provides weather forecasting",
+        )
+
+        result = await svc.search_agents(query="payment", filters={})
+
+        assert any("payment" in a["description"].lower() for a in result["items"])
+
+    @pytest.mark.asyncio
+    async def it_filters_by_min_reputation(self, mock_zerodb_client):
+        """search_agents excludes listings below min_reputation threshold."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        # Manually insert a row with known reputation
+        import uuid
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        mock_zerodb_client.data.setdefault("marketplace_listings", [])
+        mock_zerodb_client.data["marketplace_listings"].append(
+            {
+                "marketplace_id": "mkt_low",
+                "agent_id": "agent_low",
+                "publisher_did": "did:hedera:testnet:p1",
+                "pricing": {},
+                "category": "other",
+                "description": "low rep agent",
+                "tags": [],
+                "reputation_score": 1.5,
+                "install_count": 0,
+                "active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+        mock_zerodb_client.data["marketplace_listings"].append(
+            {
+                "marketplace_id": "mkt_high",
+                "agent_id": "agent_high",
+                "publisher_did": "did:hedera:testnet:p1",
+                "pricing": {},
+                "category": "other",
+                "description": "high rep agent",
+                "tags": [],
+                "reputation_score": 4.5,
+                "install_count": 0,
+                "active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+        result = await svc.search_agents(query="agent", filters={"min_reputation": 3.0})
+
+        mids = [a["marketplace_id"] for a in result["items"]]
+        assert "mkt_high" in mids
+        assert "mkt_low" not in mids
+
+    @pytest.mark.asyncio
+    async def it_filters_by_price_range(self, mock_zerodb_client):
+        """search_agents excludes listings outside price_range."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        mock_zerodb_client.data.setdefault("marketplace_listings", [])
+        mock_zerodb_client.data["marketplace_listings"].append(
+            {
+                "marketplace_id": "mkt_cheap",
+                "agent_id": "a1",
+                "publisher_did": "did:hedera:testnet:p1",
+                "pricing": {"price_per_call": 0.001},
+                "category": "other",
+                "description": "cheap agent",
+                "tags": [],
+                "reputation_score": 3.0,
+                "install_count": 0,
+                "active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+        mock_zerodb_client.data["marketplace_listings"].append(
+            {
+                "marketplace_id": "mkt_expensive",
+                "agent_id": "a2",
+                "publisher_did": "did:hedera:testnet:p1",
+                "pricing": {"price_per_call": 10.0},
+                "category": "other",
+                "description": "expensive agent",
+                "tags": [],
+                "reputation_score": 3.0,
+                "install_count": 0,
+                "active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+        result = await svc.search_agents(
+            query="agent",
+            filters={"price_range": {"min": 0.0, "max": 1.0}},
+        )
+
+        mids = [a["marketplace_id"] for a in result["items"]]
+        assert "mkt_cheap" in mids
+        assert "mkt_expensive" not in mids
+
+
+class DescribeGetCategories:
+    """Tests for get_categories — Issue #215."""
+
+    @pytest.mark.asyncio
+    async def it_returns_list_of_category_strings(self, mock_zerodb_client):
+        """get_categories returns a non-empty list of category names."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        categories = await svc.get_categories()
+
+        assert isinstance(categories, list)
+        assert len(categories) > 0
+        assert "finance" in categories
+
+
+# ---------------------------------------------------------------------------
+# Issue #216 — Install Agent into Project
+# ---------------------------------------------------------------------------
+
+
+class DescribeInstallAgent:
+    """Tests for install_agent — Issue #216."""
+
+    @pytest.mark.asyncio
+    async def it_clones_agent_config_into_project(self, mock_zerodb_client):
+        """install_agent creates an installation record in agent_installations."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        published = await svc.publish_agent(
+            agent_config={"name": "InstallMe"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        mid = published["marketplace_id"]
+
+        result = await svc.install_agent(
+            project_id="proj_123", marketplace_agent_id=mid
+        )
+
+        assert "installation_id" in result
+        assert result["project_id"] == "proj_123"
+        assert result["marketplace_agent_id"] == mid
+        rows = mock_zerodb_client.get_table_data("agent_installations")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def it_raises_not_found_for_unknown_marketplace_agent(
+        self, mock_zerodb_client
+    ):
+        """install_agent raises MarketplaceNotFoundError for unknown agent."""
+        from app.services.marketplace_service import (
+            MarketplaceService,
+            MarketplaceNotFoundError,
+        )
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+
+        with pytest.raises(MarketplaceNotFoundError):
+            await svc.install_agent(
+                project_id="proj_123", marketplace_agent_id="ghost_id"
+            )
+
+
+class DescribeListInstalled:
+    """Tests for list_installed — Issue #216."""
+
+    @pytest.mark.asyncio
+    async def it_lists_agents_installed_in_project(self, mock_zerodb_client):
+        """list_installed returns all installations for a project."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        for i in range(2):
+            pub = await svc.publish_agent(
+                agent_config={"name": f"Bot{i}"},
+                publisher_did="did:hedera:testnet:pub1",
+                pricing={"price_per_call": 0.01},
+            )
+            await svc.install_agent(
+                project_id="proj_abc", marketplace_agent_id=pub["marketplace_id"]
+            )
+
+        installed = await svc.list_installed("proj_abc")
+
+        assert len(installed) == 2
+        assert all(item["project_id"] == "proj_abc" for item in installed)
+
+    @pytest.mark.asyncio
+    async def it_returns_empty_list_for_project_with_no_installs(
+        self, mock_zerodb_client
+    ):
+        """list_installed returns [] when project has no agents installed."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        result = await svc.list_installed("empty_project")
+
+        assert result == []
+
+
+class DescribeUninstallAgent:
+    """Tests for uninstall_agent — Issue #216."""
+
+    @pytest.mark.asyncio
+    async def it_removes_installation_record(self, mock_zerodb_client):
+        """uninstall_agent deletes the installation and returns success."""
+        from app.services.marketplace_service import MarketplaceService
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+        pub = await svc.publish_agent(
+            agent_config={"name": "RemoveMe"},
+            publisher_did="did:hedera:testnet:pub1",
+            pricing={"price_per_call": 0.01},
+        )
+        install = await svc.install_agent(
+            project_id="proj_del", marketplace_agent_id=pub["marketplace_id"]
+        )
+
+        result = await svc.uninstall_agent(
+            project_id="proj_del", agent_id=install["installation_id"]
+        )
+
+        assert result["success"] is True
+        rows = mock_zerodb_client.get_table_data("agent_installations")
+        assert all(r.get("installation_id") != install["installation_id"] for r in rows)
+
+    @pytest.mark.asyncio
+    async def it_raises_not_found_for_unknown_installation(self, mock_zerodb_client):
+        """uninstall_agent raises MarketplaceNotFoundError for unknown installation."""
+        from app.services.marketplace_service import (
+            MarketplaceService,
+            MarketplaceNotFoundError,
+        )
+
+        svc = MarketplaceService(client=mock_zerodb_client)
+
+        with pytest.raises(MarketplaceNotFoundError):
+            await svc.uninstall_agent(project_id="proj_x", agent_id="ghost")

--- a/backend/app/tests/test_trustless_e2e.py
+++ b/backend/app/tests/test_trustless_e2e.py
@@ -1,0 +1,226 @@
+"""
+End-to-end user journey test for the Trustless V1 Runtime + Marketplace.
+
+Issue #237: E2E User Journey Test.
+
+Journey:
+  1. Register agent DID identity
+  2. Publish agent to marketplace
+  3. Discover service via x402 registry
+  4. Execute service call (x402 payment simulation)
+  5. Verify receipt returned
+  6. Check governance policy enforcement
+  7. Confirm reputation anchoring data structure
+
+Uses all services from Sprints 1-4 where available;
+mocks external network calls.
+
+TDD: BDD-style class DescribeE2E / def it_*
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class DescribeTrustlessE2EJourney:
+    """
+    Full trustless agent lifecycle: register → publish → discover
+    → execute service → verify receipt → governance check.
+    """
+
+    @pytest.mark.asyncio
+    async def it_completes_full_agent_publish_and_service_execution_journey(
+        self, mock_zerodb_client
+    ):
+        """
+        An agent can be published, discovered as a service, invoked via x402,
+        and a receipt is produced — end-to-end.
+        """
+        from app.services.marketplace_service import MarketplaceService
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        marketplace = MarketplaceService(client=mock_zerodb_client)
+        runtime = TrustlessRuntimeService(client=mock_zerodb_client)
+        governance = GovernancePolicyService(client=mock_zerodb_client)
+
+        agent_did = "did:hedera:testnet:e2e_agent_001"
+        caller_did = "did:hedera:testnet:e2e_caller_001"
+
+        # Step 1: Publish agent to marketplace
+        listing = await marketplace.publish_agent(
+            agent_config={"name": "E2E Analytics Agent", "model": "gpt-4"},
+            publisher_did=agent_did,
+            pricing={"price_per_call": 0.01},
+            category="analytics",
+            description="End-to-end analytics service for testing",
+        )
+        assert listing["marketplace_id"].startswith("mkt_")
+        assert listing["publisher_did"] == agent_did
+
+        # Step 2: Register service for x402 discovery
+        service = await runtime.register_service(
+            agent_did=agent_did,
+            service_description="E2E analytics",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://e2e-agent.example/x402",
+            capabilities=["analytics", "finance"],
+        )
+        assert service["service_id"].startswith("svc_")
+
+        # Step 3: Discover service by capability
+        discovered = await runtime.discover_services(
+            capability="analytics", max_price=1.0
+        )
+        assert len(discovered) >= 1
+        assert any(s["agent_did"] == agent_did for s in discovered)
+
+        # Step 4: Establish governance policy (spend limit)
+        policy = await governance.create_policy(
+            agent_did=caller_did,
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 100.0, "per_call_limit_usd": 5.0},
+        )
+        assert policy["policy_id"].startswith("pol_")
+
+        # Step 5: Evaluate governance before executing
+        gov_result = await governance.evaluate_policy(
+            agent_did=caller_did,
+            action="spend",
+            context={"amount_usd": 0.01},
+        )
+        assert gov_result["allowed"] is True
+
+        # Step 6: Execute service call (x402 payment simulation)
+        service_id = service["service_id"]
+        receipt = await runtime.execute_service_call(
+            caller_did=caller_did,
+            service_id=service_id,
+            payload={"query": "revenue trend Q1 2026"},
+        )
+
+        # Step 7: Verify receipt
+        assert "receipt_id" in receipt
+        assert receipt["receipt_id"].startswith("rcpt_")
+        assert "payment_tx" in receipt
+        assert receipt["service_id"] == service_id
+        assert receipt["caller_did"] == caller_did
+        assert receipt["agent_did"] == agent_did
+        assert "executed_at" in receipt
+
+        # Verify receipt persisted
+        receipts = mock_zerodb_client.get_table_data("service_receipts")
+        assert len(receipts) == 1
+        assert receipts[0]["receipt_id"] == receipt["receipt_id"]
+
+    @pytest.mark.asyncio
+    async def it_blocks_e2e_journey_when_governance_policy_violated(
+        self, mock_zerodb_client
+    ):
+        """
+        When an agent's spend_limit policy blocks a call, the governance
+        check returns allowed=False before any service invocation.
+        """
+        from app.services.governance_policy_service import GovernancePolicyService
+
+        governance = GovernancePolicyService(client=mock_zerodb_client)
+        caller_did = "did:hedera:testnet:restricted_caller"
+
+        await governance.create_policy(
+            agent_did=caller_did,
+            policy_type="spend_limit",
+            rules={"daily_limit_usd": 10.0, "per_call_limit_usd": 0.005},
+        )
+
+        result = await governance.evaluate_policy(
+            agent_did=caller_did,
+            action="spend",
+            context={"amount_usd": 1.0},  # exceeds per_call_limit
+        )
+
+        assert result["allowed"] is False
+        assert len(result["violated_policies"]) > 0
+
+    @pytest.mark.asyncio
+    async def it_verifies_on_chain_identity_during_marketplace_publish(self):
+        """
+        When an agent publishes with a DID that encodes an NFT, the on-chain
+        identity can be verified via MarketplaceHederaService.
+        """
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+        from app.services.hedera_hts_nft_client import HederaHTSNFTClientError
+
+        mock_nft = AsyncMock()
+        mock_nft.get_nft_info = AsyncMock(
+            return_value={
+                "token_id": "0.0.888",
+                "serial_number": 7,
+                "metadata": "e30=",
+                "account_id": "0.0.222",
+            }
+        )
+        hedera_svc = MarketplaceHederaService(nft_client=mock_nft)
+
+        # DID encodes token_id=0.0.888, serial=7
+        result = await hedera_svc.verify_on_chain_identity(
+            "did:hedera:testnet:e2eagent_0.0.888_7"
+        )
+        assert result["verified"] is True
+        assert result["token_id"] == "0.0.888"
+        assert result["serial"] == 7
+
+    @pytest.mark.asyncio
+    async def it_can_link_marketplace_listing_to_nft_after_publish(self):
+        """
+        After publishing, a listing can be cross-referenced with its NFT via
+        link_marketplace_to_nft.
+        """
+        from app.services.marketplace_hedera_service import MarketplaceHederaService
+
+        hedera_svc = MarketplaceHederaService(nft_client=AsyncMock())
+        linkage = await hedera_svc.link_marketplace_to_nft(
+            marketplace_id="mkt_e2e001",
+            nft_token_id="0.0.777",
+            serial=3,
+        )
+        assert linkage["marketplace_id"] == "mkt_e2e001"
+        assert linkage["nft_token_id"] == "0.0.777"
+        assert linkage["serial"] == 3
+
+    @pytest.mark.asyncio
+    async def it_supports_browse_then_install_workflow(self, mock_zerodb_client):
+        """
+        A user can browse the marketplace, find an agent, and install it
+        into their project — the standard end-user onboarding flow.
+        """
+        from app.services.marketplace_service import MarketplaceService
+
+        marketplace = MarketplaceService(client=mock_zerodb_client)
+
+        # Publisher side: publish two agents
+        for i in range(2):
+            await marketplace.publish_agent(
+                agent_config={"name": f"PublicAgent{i}"},
+                publisher_did="did:hedera:testnet:publisher",
+                pricing={"price_per_call": 0.01 * (i + 1)},
+                category="analytics",
+            )
+
+        # Consumer side: browse then install
+        browse_result = await marketplace.browse_agents(
+            category="analytics", sort_by="newest", limit=10, offset=0
+        )
+        assert browse_result["total"] == 2
+
+        first_agent = browse_result["items"][0]
+        installation = await marketplace.install_agent(
+            project_id="consumer_project_001",
+            marketplace_agent_id=first_agent["marketplace_id"],
+        )
+        assert installation["project_id"] == "consumer_project_001"
+
+        installed = await marketplace.list_installed("consumer_project_001")
+        assert len(installed) == 1

--- a/backend/app/tests/test_trustless_runtime_service.py
+++ b/backend/app/tests/test_trustless_runtime_service.py
@@ -1,0 +1,256 @@
+"""
+Tests for TrustlessRuntimeService.
+Issue #235: Agent Runtime with x402 Service Advertising.
+
+TDD: RED phase — tests written before implementation.
+BDD-style: class Describe* / def it_*
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class DescribeTrustlessRuntimeServiceInit:
+    """TrustlessRuntimeService initializes correctly."""
+
+    def it_initializes_with_lazy_zerodb_client(self):
+        """Service starts with no client stored."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService()
+        assert svc._client is None
+
+    def it_accepts_injected_client(self):
+        """Service accepts a pre-built client."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        mock = MagicMock()
+        svc = TrustlessRuntimeService(client=mock)
+        assert svc.client is mock
+
+
+class DescribeRegisterService:
+    """Tests for register_service — Issue #235."""
+
+    @pytest.mark.asyncio
+    async def it_registers_service_and_returns_entry(self, mock_zerodb_client):
+        """register_service stores entry and returns service_id."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        result = await svc.register_service(
+            agent_did="did:hedera:testnet:agent1",
+            service_description="Pricing analytics service",
+            pricing={"price_per_call": 0.02},
+            x402_endpoint="https://agent1.example/x402",
+        )
+
+        assert "service_id" in result
+        assert result["agent_did"] == "did:hedera:testnet:agent1"
+        assert result["x402_endpoint"] == "https://agent1.example/x402"
+
+    @pytest.mark.asyncio
+    async def it_stores_service_in_service_registry_table(self, mock_zerodb_client):
+        """register_service inserts exactly one row into service_registry."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        await svc.register_service(
+            agent_did="did:hedera:testnet:agent2",
+            service_description="Document summariser",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://agent2.example/x402",
+        )
+
+        rows = mock_zerodb_client.get_table_data("service_registry")
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def it_generates_unique_service_ids(self, mock_zerodb_client):
+        """Two register_service calls produce different service_ids."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        r1 = await svc.register_service(
+            agent_did="did:hedera:testnet:a1",
+            service_description="Service A",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://a1.example/x402",
+        )
+        r2 = await svc.register_service(
+            agent_did="did:hedera:testnet:a2",
+            service_description="Service B",
+            pricing={"price_per_call": 0.02},
+            x402_endpoint="https://a2.example/x402",
+        )
+
+        assert r1["service_id"] != r2["service_id"]
+
+
+class DescribeDiscoverServices:
+    """Tests for discover_services — Issue #235."""
+
+    @pytest.mark.asyncio
+    async def it_returns_services_matching_capability(self, mock_zerodb_client):
+        """discover_services returns entries that declare the requested capability."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        await svc.register_service(
+            agent_did="did:hedera:testnet:a1",
+            service_description="Finance analytics",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://a1.example/x402",
+            capabilities=["analytics", "finance"],
+        )
+        await svc.register_service(
+            agent_did="did:hedera:testnet:a2",
+            service_description="Weather forecasting",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://a2.example/x402",
+            capabilities=["weather"],
+        )
+
+        results = await svc.discover_services(capability="finance", max_price=None)
+
+        assert len(results) == 1
+        assert results[0]["agent_did"] == "did:hedera:testnet:a1"
+
+    @pytest.mark.asyncio
+    async def it_filters_by_max_price(self, mock_zerodb_client):
+        """discover_services excludes services above max_price."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        await svc.register_service(
+            agent_did="did:hedera:testnet:cheap",
+            service_description="Cheap analytics",
+            pricing={"price_per_call": 0.005},
+            x402_endpoint="https://cheap.example/x402",
+            capabilities=["analytics"],
+        )
+        await svc.register_service(
+            agent_did="did:hedera:testnet:expensive",
+            service_description="Expensive analytics",
+            pricing={"price_per_call": 5.0},
+            x402_endpoint="https://expensive.example/x402",
+            capabilities=["analytics"],
+        )
+
+        results = await svc.discover_services(capability="analytics", max_price=0.1)
+
+        dids = [r["agent_did"] for r in results]
+        assert "did:hedera:testnet:cheap" in dids
+        assert "did:hedera:testnet:expensive" not in dids
+
+    @pytest.mark.asyncio
+    async def it_returns_empty_list_when_no_match(self, mock_zerodb_client):
+        """discover_services returns [] when no services match."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        results = await svc.discover_services(capability="quantum_teleportation", max_price=None)
+
+        assert results == []
+
+
+class DescribeExecuteServiceCall:
+    """Tests for execute_service_call — Issue #235."""
+
+    @pytest.mark.asyncio
+    async def it_returns_receipt_with_payment_tx(self, mock_zerodb_client):
+        """execute_service_call returns a receipt containing payment_tx."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        reg = await svc.register_service(
+            agent_did="did:hedera:testnet:provider",
+            service_description="Data fetch",
+            pricing={"price_per_call": 0.01},
+            x402_endpoint="https://provider.example/x402",
+        )
+
+        receipt = await svc.execute_service_call(
+            caller_did="did:hedera:testnet:caller",
+            service_id=reg["service_id"],
+            payload={"query": "AAPL price"},
+        )
+
+        assert "receipt_id" in receipt
+        assert "payment_tx" in receipt
+        assert receipt["service_id"] == reg["service_id"]
+        assert receipt["caller_did"] == "did:hedera:testnet:caller"
+
+    @pytest.mark.asyncio
+    async def it_raises_for_unknown_service_id(self, mock_zerodb_client):
+        """execute_service_call raises ServiceNotFoundError for unknown service_id."""
+        from app.services.trustless_runtime_service import (
+            TrustlessRuntimeService,
+            ServiceNotFoundError,
+        )
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+
+        with pytest.raises(ServiceNotFoundError):
+            await svc.execute_service_call(
+                caller_did="did:hedera:testnet:caller",
+                service_id="ghost_service",
+                payload={},
+            )
+
+    @pytest.mark.asyncio
+    async def it_stores_receipt_in_service_receipts_table(self, mock_zerodb_client):
+        """execute_service_call persists a receipt row."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        reg = await svc.register_service(
+            agent_did="did:hedera:testnet:prov2",
+            service_description="Summarizer",
+            pricing={"price_per_call": 0.02},
+            x402_endpoint="https://prov2.example/x402",
+        )
+
+        await svc.execute_service_call(
+            caller_did="did:hedera:testnet:caller2",
+            service_id=reg["service_id"],
+            payload={"text": "Hello world"},
+        )
+
+        rows = mock_zerodb_client.get_table_data("service_receipts")
+        assert len(rows) == 1
+
+
+class DescribeGetServiceRegistry:
+    """Tests for get_service_registry — Issue #235."""
+
+    @pytest.mark.asyncio
+    async def it_returns_all_registered_services(self, mock_zerodb_client):
+        """get_service_registry returns every registered service."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        for i in range(3):
+            await svc.register_service(
+                agent_did=f"did:hedera:testnet:a{i}",
+                service_description=f"Service {i}",
+                pricing={"price_per_call": 0.01},
+                x402_endpoint=f"https://a{i}.example/x402",
+            )
+
+        registry = await svc.get_service_registry()
+
+        assert len(registry) == 3
+
+    @pytest.mark.asyncio
+    async def it_returns_empty_list_when_nothing_registered(self, mock_zerodb_client):
+        """get_service_registry returns [] when no services exist."""
+        from app.services.trustless_runtime_service import TrustlessRuntimeService
+
+        svc = TrustlessRuntimeService(client=mock_zerodb_client)
+        registry = await svc.get_service_registry()
+
+        assert registry == []


### PR DESCRIPTION
## Summary
- Agent marketplace: publish, browse, search, install (#214-216)
- On-chain agent identity via Hedera (#217)
- Trustless runtime with x402 service advertising (#235)
- Agent self-governance policies (#236)
- E2E user journey test (#237)

Closes #214, Closes #215, Closes #216, Closes #217, Closes #235, Closes #236, Closes #237