### PR TITLE
feat(middleware): WorkshopPrefixMiddleware for /api/v1/ path rewriting (B0)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -112,6 +112,18 @@ class Settings(BaseSettings):
         description="LLM provider to use (gemini, openai, anthropic)"
     )
 
+    # Workshop Mode (Refs #285, #300)
+    # When enabled, /api/v1/* paths are rewritten to /v1/public/{workshop_default_project_id}/*
+    # so tutorials can use a flat prefix without project ids in URLs.
+    workshop_mode: bool = Field(
+        default=False,
+        description="Enable workshop /api/v1/ prefix rewriting"
+    )
+    workshop_default_project_id: str = Field(
+        default="proj_workshop",
+        description="Default project id substituted when rewriting /api/v1/* in workshop mode"
+    )
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -154,6 +154,8 @@ try:
 except ImportError:
     hedera_audit_router = None
 from app.middleware import APIKeyAuthMiddleware, ImmutableMiddleware
+# Refs #285, #300: Workshop-mode path rewriter for flat /api/v1/* prefix
+from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
 
 
 # Create FastAPI application
@@ -182,6 +184,18 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+# Workshop-mode path rewriter - must be outermost so downstream middleware
+# (auth, immutable) see the rewritten /v1/public/... path. Gated by
+# settings.workshop_mode so production is unaffected by default.
+# Overrides are populated by B2 (#302) and B3 (#303) for non-conventional
+# prefixes (hcs10, anchor, marketplace).
+app.add_middleware(
+    WorkshopPrefixMiddleware,
+    enabled=settings.workshop_mode,
+    default_project_id=settings.workshop_default_project_id,
+    overrides={},
 )
 
 

--- a/backend/app/middleware/workshop_prefix.py
+++ b/backend/app/middleware/workshop_prefix.py
@@ -1,0 +1,108 @@
+"""
+Workshop-mode path-rewrite ASGI middleware.
+
+Refs #300, #285. Enables workshop tutorials to hit endpoints under a flat
+`/api/v1/*` prefix without duplicating handlers. The middleware rewrites
+incoming paths before routing, so all existing route handlers remain the
+source of truth.
+
+Behavior:
+- Only active when `enabled=True` (driven by `settings.workshop_mode`).
+- Default convention: `/api/v1/<suffix>` -> `/v1/public/<default_project_id>/<suffix>`
+- Override registry rewrites non-conventional paths (e.g. `/hcs10/*`,
+  `/marketplace/*`) to their true prefix. Overrides are checked first.
+- Legacy paths are never modified.
+- Non-HTTP ASGI scopes (lifespan, websocket) are passed through unchanged.
+
+Implemented as a pure ASGI middleware (not BaseHTTPMiddleware) so the rewrite
+lands on `scope["path"]` before route matching, not after the handler has
+already been selected.
+
+Built by AINative Dev Team
+"""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Mapping, MutableMapping, Optional
+
+_API_V1_PREFIX = "/api/v1/"
+
+
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+
+
+class WorkshopPrefixMiddleware:
+    """
+    Rewrite `/api/v1/*` requests to their underlying router prefix.
+
+    Args:
+        app: Downstream ASGI application.
+        enabled: When False, the middleware is a no-op and `/api/v1/*` paths
+            are left alone (and will 404 unless another router claims them).
+        default_project_id: Substituted into the convention mapping
+            `/api/v1/<suffix>` -> `/v1/public/<default_project_id>/<suffix>`.
+        overrides: Optional mapping of `suffix -> target_prefix`. When the
+            stripped `/api/v1/` remainder starts with one of the suffixes,
+            the remainder after the suffix is appended to the target prefix.
+            Example: `{"hcs10/": "/hcs10/"}` routes `/api/v1/hcs10/send` to
+            `/hcs10/send`.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        enabled: bool = False,
+        default_project_id: str = "",
+        overrides: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.app = app
+        self.enabled = enabled
+        self.default_project_id = default_project_id
+        self.overrides: Dict[str, str] = dict(overrides or {})
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._should_rewrite(scope):
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        new_path = self._rewrite_path(path)
+        if new_path == path:
+            await self.app(scope, receive, send)
+            return
+
+        # Shallow-copy scope and replace path + raw_path. Starlette routing reads
+        # both; keep them in sync so path parameters and query strings resolve
+        # against the rewritten URL.
+        new_scope: Scope = dict(scope)
+        new_scope["path"] = new_path
+        new_scope["raw_path"] = new_path.encode("utf-8")
+        await self.app(new_scope, receive, send)
+
+    def _should_rewrite(self, scope: Mapping[str, Any]) -> bool:
+        """Only rewrite live HTTP requests when the feature flag is on."""
+        if not self.enabled:
+            return False
+        return scope.get("type") == "http"
+
+    def _rewrite_path(self, path: str) -> str:
+        """Compute the rewritten path, or return the original if no rule matches."""
+        if not path.startswith(_API_V1_PREFIX):
+            return path
+
+        suffix = path[len(_API_V1_PREFIX):]
+
+        # Overrides win over convention so non-project-scoped routes (hcs10,
+        # marketplace, anchor/*) can be mapped to their true prefix.
+        for key, target in self.overrides.items():
+            if suffix.startswith(key):
+                remainder = suffix[len(key):]
+                if not target.endswith("/"):
+                    target = target + "/"
+                return target + remainder
+
+        # Default convention: prefix with default project id
+        if not self.default_project_id:
+            return path
+        return f"/v1/public/{self.default_project_id}/{suffix}"

--- a/backend/app/tests/middleware/__init__.py
+++ b/backend/app/tests/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for middleware package."""

--- a/backend/app/tests/middleware/test_workshop_prefix.py
+++ b/backend/app/tests/middleware/test_workshop_prefix.py
@@ -1,0 +1,331 @@
+"""
+Unit tests for WorkshopPrefixMiddleware.
+
+Refs #300, #285.
+
+The middleware rewrites `/api/v1/<path>` to the underlying router prefix when
+`WORKSHOP_MODE=true`. When disabled, `/api/v1/*` must 404.
+
+Behavior:
+- Default convention: `/api/v1/<domain>/...`
+    -> `/v1/public/<default_project_id>/<domain>/...`
+- Override registry lets B2/B3 map non-conventional paths (e.g. `/hcs10/*`,
+  `/marketplace/*`) without editing the middleware file.
+- HTTP method, body, headers, and query string are preserved.
+- Path parameters carry through because only the prefix is rewritten.
+- Legacy `/v1/public/{project_id}/...` paths are untouched in both modes.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def echo_app():
+    """Build a minimal FastAPI app that echoes path + method + query back."""
+    app = FastAPI()
+
+    @app.get("/v1/public/{project_id}/agents")
+    async def list_agents(project_id: str, limit: int = 10):
+        return {"project_id": project_id, "limit": limit, "route": "agents"}
+
+    @app.get("/v1/public/{project_id}/agent-memory/{memory_id}")
+    async def get_memory(project_id: str, memory_id: str):
+        return {"project_id": project_id, "memory_id": memory_id, "route": "memory"}
+
+    @app.post("/v1/public/{project_id}/agent-memory")
+    async def create_memory(project_id: str, body: dict):
+        return {"project_id": project_id, "body": body, "route": "create_memory"}
+
+    @app.get("/marketplace/listings")
+    async def list_marketplace():
+        return {"route": "marketplace"}
+
+    @app.post("/hcs10/send")
+    async def hcs10_send(body: dict):
+        return {"body": body, "route": "hcs10_send"}
+
+    return app
+
+
+class DescribeWorkshopPrefixMiddlewareDisabled:
+    """When WORKSHOP_MODE is off, /api/v1/* must not resolve."""
+
+    def it_returns_404_for_api_v1_path(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=False,
+            default_project_id="proj_test",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/agents")
+
+        assert response.status_code == 404
+
+    def it_leaves_legacy_routes_working(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=False,
+            default_project_id="proj_test",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/v1/public/proj_xyz/agents")
+
+        assert response.status_code == 200
+        assert response.json()["project_id"] == "proj_xyz"
+
+
+class DescribeWorkshopPrefixMiddlewareEnabled:
+    """When WORKSHOP_MODE is on, /api/v1/* is rewritten."""
+
+    def it_rewrites_api_v1_to_default_project(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/agents")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["project_id"] == "proj_workshop"
+        assert body["route"] == "agents"
+
+    def it_preserves_query_string(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/agents?limit=42")
+
+        assert response.status_code == 200
+        assert response.json()["limit"] == 42
+
+    def it_preserves_path_parameters(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/agent-memory/mem_abc123")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["memory_id"] == "mem_abc123"
+        assert body["project_id"] == "proj_workshop"
+
+    def it_preserves_method_and_body_on_post(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        payload = {"content": "hello", "type": "semantic"}
+        response = client.post("/api/v1/agent-memory", json=payload)
+
+        assert response.status_code == 200
+        assert response.json()["body"] == payload
+
+    def it_leaves_legacy_routes_untouched_when_enabled(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/v1/public/proj_other/agents")
+
+        assert response.status_code == 200
+        assert response.json()["project_id"] == "proj_other"
+
+    def it_leaves_non_api_v1_paths_untouched(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/marketplace/listings")
+
+        assert response.status_code == 200
+
+
+class DescribeWorkshopPrefixOverrides:
+    """Overrides route non-conventional /api/v1/* prefixes to the right target."""
+
+    def it_uses_override_for_marketplace(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+            overrides={"marketplace/": "/marketplace/"},
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/marketplace/listings")
+
+        assert response.status_code == 200
+        assert response.json()["route"] == "marketplace"
+
+    def it_uses_override_for_hcs10(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+            overrides={"hcs10/": "/hcs10/"},
+        )
+        client = TestClient(echo_app)
+
+        response = client.post("/api/v1/hcs10/send", json={"msg": "hi"})
+
+        assert response.status_code == 200
+        assert response.json()["body"] == {"msg": "hi"}
+
+    def it_prefers_override_over_default_convention(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+            overrides={"marketplace/": "/marketplace/"},
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/marketplace/listings")
+
+        assert response.status_code == 200
+        assert response.json()["route"] == "marketplace"
+
+
+class DescribeWorkshopPrefixEdgeCases:
+    """Defensive behavior on odd inputs."""
+
+    def it_handles_exact_prefix_with_no_suffix(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        echo_app.add_middleware(
+            WorkshopPrefixMiddleware,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+        client = TestClient(echo_app)
+
+        response = client.get("/api/v1/")
+
+        assert response.status_code in (404, 405)
+
+    def it_bypasses_websocket_scope(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+
+        assert mw._should_rewrite({"type": "lifespan", "path": "/api/v1/agents"}) is False
+        assert mw._should_rewrite({"type": "websocket", "path": "/api/v1/agents"}) is False
+        assert mw._should_rewrite({"type": "http", "path": "/api/v1/agents"}) is True
+
+    def it_rewrite_returns_unchanged_for_non_api_v1(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="proj_workshop",
+        )
+
+        assert mw._rewrite_path("/health") == "/health"
+        assert mw._rewrite_path("/v1/public/p/x") == "/v1/public/p/x"
+
+    def it_rewrite_applies_default_convention(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="proj_ws",
+        )
+
+        assert mw._rewrite_path("/api/v1/agents") == "/v1/public/proj_ws/agents"
+        assert (
+            mw._rewrite_path("/api/v1/agent-memory/mem_1")
+            == "/v1/public/proj_ws/agent-memory/mem_1"
+        )
+
+    def it_rewrite_applies_overrides_first(self, echo_app):
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="proj_ws",
+            overrides={"anchor/": "/anchor/", "hcs10/": "/hcs10/"},
+        )
+
+        assert mw._rewrite_path("/api/v1/anchor/memory") == "/anchor/memory"
+        assert mw._rewrite_path("/api/v1/hcs10/send") == "/hcs10/send"
+        # Non-override path still uses convention
+        assert mw._rewrite_path("/api/v1/agents") == "/v1/public/proj_ws/agents"
+
+    def it_appends_trailing_slash_to_override_target(self, echo_app):
+        """Override targets missing a trailing slash are normalized."""
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="proj_ws",
+            overrides={"marketplace/": "/marketplace"},  # no trailing slash
+        )
+
+        assert mw._rewrite_path("/api/v1/marketplace/listings") == "/marketplace/listings"
+
+    def it_leaves_path_unchanged_when_no_default_project_and_no_override(self, echo_app):
+        """Safety: empty default_project_id + no matching override => unchanged."""
+        from app.middleware.workshop_prefix import WorkshopPrefixMiddleware
+
+        mw = WorkshopPrefixMiddleware(
+            app=echo_app,
+            enabled=True,
+            default_project_id="",
+        )
+
+        assert mw._rewrite_path("/api/v1/agents") == "/api/v1/agents"


### PR DESCRIPTION
## Summary

- Adds a pure-ASGI `WorkshopPrefixMiddleware` that rewrites `/api/v1/<suffix>` requests to the underlying router prefix when `WORKSHOP_MODE=true`, so workshop tutorials can use a flat, project-id-free URL without duplicating route handlers.
- Introduces `workshop_mode` and `workshop_default_project_id` settings.
- Wires the middleware as the outermost layer in `app.main` so downstream middleware (auth, immutable, CORS) sees the rewritten path.
- Serial seed for the #285 split — unblocks parallel worktrees B1 (#301), B2 (#302), B3 (#303).

## Test plan

- [x] 18 unit tests for disabled/enabled/overrides/edge cases pass
- [x] 100% line coverage on `app.middleware.workshop_prefix`
- [x] `python3 -c "import app.main"` succeeds — wiring verified
- [ ] Integration tests will follow in B1/B2/B3 (each wires its own domain's route aliasing)

## Coverage

```
Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
app/middleware/workshop_prefix.py      42      0   100%
-----------------------------------------------------------------
TOTAL                                  42      0   100%
```

## Design notes

- Pure-ASGI (not `BaseHTTPMiddleware`) so `scope["path"]` mutation lands **before** Starlette route matching.
- Override registry lets B2/B3 add non-conventional prefixes (hcs10, marketplace, anchor) without editing the middleware file — avoids file conflicts between parallel worktrees.
- Parent `app/tests/conftest.py` has a pre-existing Python 3.9 / cryptography / PyO3 double-init issue under `pytest-cov`. Coverage measured via `coverage run --include=` which bypasses eager source imports. Follow-up: refactor conftest to lazy-import `app.main`.

Closes #300
Refs #285

Built by AINative Dev Team