### PR TITLE
feat(cognitive-memory): implement POST /memory/recall (S2)

### DIFF
--- a/backend/app/api/cognitive/recall.py
+++ b/backend/app/api/cognitive/recall.py
@@ -1,30 +1,121 @@
 """
 POST /v1/public/{project_id}/memory/recall — cognitive recall endpoint.
 
-Refs #292. S0 (#308) lands a 501 stub; S2 (#310) replaces with real
-semantic retrieval + recency/importance weighting.
+Refs #292, #310 (S2).
+
+Semantic retrieval over agent memories with recency + importance
+weighting. Composite score = similarity*w_sim + recency*w_rec +
+importance*w_imp. Results are sorted by composite score descending and
+truncated to `limit`.
+
+Falls back gracefully when legacy memory records have no `importance`
+field — those default to 0.5 (neutral).
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from typing import Any, Dict, List
 
-from app.schemas.cognitive_memory import RecallRequest, RecallResponse
+from fastapi import APIRouter, Path, status
+
+from app.schemas.cognitive_memory import (
+    CognitiveMemoryType,
+    MemoryCategory,
+    RecallItem,
+    RecallRequest,
+    RecallResponse,
+    RecallWeights,
+)
+from app.services.agent_memory_service import agent_memory_service
+from app.services.cognitive_memory_service import get_cognitive_memory_service
 
 router = APIRouter(prefix="/v1/public", tags=["cognitive-memory"])
+
+
+def _parse_category(raw: Any) -> MemoryCategory:
+    """Safely map a string to MemoryCategory, defaulting to OTHER."""
+    if isinstance(raw, MemoryCategory):
+        return raw
+    try:
+        return MemoryCategory(raw)
+    except (ValueError, TypeError):
+        return MemoryCategory.OTHER
+
+
+def _parse_memory_type(raw: Any) -> CognitiveMemoryType:
+    """Safely map a string to CognitiveMemoryType, defaulting to WORKING."""
+    if isinstance(raw, CognitiveMemoryType):
+        return raw
+    try:
+        return CognitiveMemoryType(raw)
+    except (ValueError, TypeError):
+        return CognitiveMemoryType.WORKING
 
 
 @router.post(
     "/{project_id}/memory/recall",
     response_model=RecallResponse,
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+    status_code=status.HTTP_200_OK,
     summary="Recall (semantic retrieval with relevance + recency)",
 )
-async def recall(project_id: str, request: RecallRequest) -> RecallResponse:
-    """Placeholder until #310 lands the real handler."""
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail={
-            "error_code": "NOT_IMPLEMENTED",
-            "detail": "POST /memory/recall not yet implemented (#310)",
-        },
+async def recall(
+    request: RecallRequest,
+    project_id: str = Path(..., min_length=1),
+) -> RecallResponse:
+    """Return memories ranked by composite relevance score."""
+    weights = request.weights or RecallWeights()
+    cognitive = get_cognitive_memory_service()
+
+    matches: List[Dict[str, Any]] = await agent_memory_service.search_memories(
+        project_id=project_id,
+        query=request.query,
+        namespace=request.namespace,
+        top_k=request.limit,
     )
+
+    items: List[RecallItem] = []
+    for match in matches:
+        if request.agent_id and match.get("agent_id") != request.agent_id:
+            continue
+
+        metadata = match.get("metadata", {}) or {}
+        importance = metadata.get("importance", 0.5)
+        try:
+            importance = float(importance)
+        except (TypeError, ValueError):
+            importance = 0.5
+
+        recency_weight = cognitive.compute_recency_weight(
+            match.get("timestamp"),
+            half_life_days=weights.half_life_days,
+        )
+        similarity = float(match.get("similarity_score", 0.0) or 0.0)
+        composite = cognitive.compose_relevance(
+            similarity=similarity,
+            recency=recency_weight,
+            importance=importance,
+            weights=weights,
+        )
+
+        items.append(
+            RecallItem(
+                memory_id=match.get("memory_id", ""),
+                agent_id=match.get("agent_id"),
+                content=match.get("content", ""),
+                category=_parse_category(metadata.get("category")),
+                memory_type=_parse_memory_type(
+                    metadata.get("cognitive_memory_type")
+                    or match.get("memory_type")
+                ),
+                importance=max(0.0, min(1.0, importance)),
+                similarity_score=similarity,
+                recency_weight=recency_weight,
+                composite_score=composite,
+                timestamp=match.get("timestamp"),
+            )
+        )
+
+    items.sort(key=lambda m: m.composite_score, reverse=True)
+    if len(items) > request.limit:
+        items = items[: request.limit]
+
+    return RecallResponse(memories=items, query=request.query, weights=weights)

--- a/backend/app/services/cognitive_memory_service.py
+++ b/backend/app/services/cognitive_memory_service.py
@@ -18,7 +18,7 @@ Design:
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from app.schemas.cognitive_memory import (
@@ -142,7 +142,7 @@ class CognitiveMemoryService:
         return MemoryCategory.OTHER
 
     # ------------------------------------------------------------------
-    # Recency weighting (real logic lands in S2)
+    # Recency weighting (Refs #310 S2)
     # ------------------------------------------------------------------
 
     def compute_recency_weight(
@@ -151,8 +151,37 @@ class CognitiveMemoryService:
         half_life_days: float = 7.0,
         now: Optional[datetime] = None,
     ) -> float:
-        """Return 1.0 placeholder (no decay). Replaced in S2 (#310)."""
-        return self.DEFAULT_RECENCY_WEIGHT
+        """
+        Exponential decay: `weight = 0.5 ** (age_days / half_life_days)`.
+
+        - `timestamp` is an ISO-8601 string (with or without trailing 'Z').
+        - Missing or malformed timestamps default to 1.0 so downstream
+          ranking still sees them.
+        - `now` is injectable for deterministic tests; defaults to UTC now.
+        """
+        if not timestamp:
+            return 1.0
+
+        ts_str = (
+            timestamp.replace("Z", "+00:00")
+            if timestamp.endswith("Z")
+            else timestamp
+        )
+        try:
+            parsed = datetime.fromisoformat(ts_str)
+        except (ValueError, TypeError):
+            return 1.0
+
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+
+        now_dt = now or datetime.now(timezone.utc)
+        if now_dt.tzinfo is None:
+            now_dt = now_dt.replace(tzinfo=timezone.utc)
+
+        age_seconds = max((now_dt - parsed).total_seconds(), 0.0)
+        age_days = age_seconds / 86400.0
+        return 0.5 ** (age_days / max(half_life_days, 1e-6))
 
     def compose_relevance(
         self,

--- a/backend/app/tests/test_cognitive_memory_scaffold.py
+++ b/backend/app/tests/test_cognitive_memory_scaffold.py
@@ -47,21 +47,11 @@ def _build_app(workshop_mode: bool = False) -> FastAPI:
 
 
 class DescribeCognitiveMemoryStubs:
-    """Stubs for endpoints not yet implemented (S2-S4)."""
+    """Stubs for endpoints not yet implemented (S3, S4)."""
 
     # /remember is implemented in S1 (#309); see test_cognitive_remember.py
-    # for its coverage. Remaining stubs below.
-
-    def it_recall_returns_501(self):
-        app = _build_app()
-        client = TestClient(app)
-
-        response = client.post(
-            f"/v1/public/{DEFAULT_PID}/memory/recall",
-            json={"query": "rate limit?"},
-        )
-
-        assert response.status_code == 501
+    # /recall   is implemented in S2 (#310); see test_cognitive_recall.py
+    # Remaining stubs below.
 
     def it_reflect_returns_501(self):
         app = _build_app()
@@ -147,36 +137,16 @@ class DescribeCognitiveMemorySchemaValidation:
 
         assert response.status_code == 422
 
-    def it_accepts_recall_with_default_weights(self):
-        """Recall request validates without explicit weights."""
-        app = _build_app()
-        client = TestClient(app)
-
-        response = client.post(
-            f"/v1/public/{DEFAULT_PID}/memory/recall",
-            json={"query": "what is the rate limit"},
-        )
-
-        # Passes validation, hits 501 stub — confirms schema accepts it.
-        assert response.status_code == 501
+    # Recall schema validation covered by test_cognitive_recall.py after
+    # S2 (#310) implemented the real handler.
 
 
 class DescribeWorkshopAliasRouting:
     """/api/v1/memory/* must resolve via convention mapping."""
 
-    # /api/v1/memory/remember routing is covered in test_cognitive_remember.py
-    # against the real (non-stub) handler. Remaining stubs below.
-
-    def it_routes_api_v1_memory_recall_to_stub(self):
-        app = _build_app(workshop_mode=True)
-        client = TestClient(app)
-
-        response = client.post(
-            "/api/v1/memory/recall",
-            json={"query": "q"},
-        )
-
-        assert response.status_code == 501
+    # /api/v1/memory/remember routing covered by test_cognitive_remember.py
+    # /api/v1/memory/recall   routing covered by test_cognitive_recall.py
+    # Remaining stubs below.
 
     def it_routes_api_v1_memory_reflect_to_stub(self):
         app = _build_app(workshop_mode=True)
@@ -236,11 +206,15 @@ class DescribeCognitiveMemoryService:
         # for non-matching text in WORKING type we still fall through to OTHER.
         assert svc.categorize("asdfghjkl", CognitiveMemoryType.WORKING) == MemoryCategory.OTHER
 
-    def it_compute_recency_weight_returns_default(self):
+    def it_compute_recency_weight_is_bounded(self):
+        """S2 (#310) replaced the constant-1.0 stub with exponential decay."""
         svc = CognitiveMemoryService()
 
-        assert svc.compute_recency_weight("2026-04-01T00:00:00Z") == 1.0
+        # None timestamp still returns 1.0
         assert svc.compute_recency_weight(None) == 1.0
+        # Decayed weight is in [0, 1]
+        decayed = svc.compute_recency_weight("2026-04-01T00:00:00Z")
+        assert 0.0 <= decayed <= 1.0
 
     def it_compose_relevance_with_default_weights(self):
         svc = CognitiveMemoryService()

--- a/backend/app/tests/test_cognitive_recall.py
+++ b/backend/app/tests/test_cognitive_recall.py
@@ -1,0 +1,312 @@
+"""
+Tests for POST /v1/public/{project_id}/memory/recall (Refs #292, #310).
+
+Covers:
+- End-to-end: handler calls `AgentMemoryService.search_memories`, applies
+  recency + importance weighting, sorts by composite score, returns
+  `RecallResponse`.
+- Service helpers: `compute_recency_weight` exponential decay, agent_id
+  filtering, missing importance defaults to 0.5.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.cognitive_memory import router as cognitive_memory_router
+from app.schemas.cognitive_memory import RecallWeights
+from app.services.cognitive_memory_service import CognitiveMemoryService
+
+DEFAULT_PID = "proj_test_s2"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(cognitive_memory_router)
+    return app
+
+
+def _memory(
+    memory_id: str,
+    content: str,
+    similarity: float = 0.8,
+    importance: float = 0.5,
+    timestamp: str = "2026-04-17T00:00:00Z",
+    agent_id: str = "agent_abc",
+    category: str = "other",
+    memory_type: str = "working",
+) -> Dict[str, Any]:
+    return {
+        "memory_id": memory_id,
+        "agent_id": agent_id,
+        "run_id": "run_1",
+        "memory_type": memory_type,
+        "content": content,
+        "metadata": {
+            "importance": importance,
+            "category": category,
+            "cognitive_memory_type": memory_type,
+        },
+        "namespace": "default",
+        "timestamp": timestamp,
+        "project_id": DEFAULT_PID,
+        "embedding_id": None,
+        "similarity_score": similarity,
+    }
+
+
+class DescribeRecallEndpoint:
+
+    def it_returns_memories_sorted_by_composite_score(self, monkeypatch):
+        app = _build_app()
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        results = [
+            _memory("mem_low_sim", "rate limit", similarity=0.3, importance=0.5, timestamp=now_iso),
+            _memory("mem_high_sim", "rate limit details", similarity=0.9, importance=0.5, timestamp=now_iso),
+            _memory("mem_mid", "rate", similarity=0.6, importance=0.5, timestamp=now_iso),
+        ]
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=results),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "what is the rate limit?", "limit": 5},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        ids = [m["memory_id"] for m in body["memories"]]
+        assert ids == ["mem_high_sim", "mem_mid", "mem_low_sim"]
+        # All composite scores must be in [0, 1.5] range (weights sum ~1)
+        for m in body["memories"]:
+            assert 0.0 <= m["composite_score"]
+            assert m["similarity_score"] >= 0.0
+            assert 0.0 <= m["recency_weight"] <= 1.0
+
+    def it_filters_results_by_agent_id_when_provided(self, monkeypatch):
+        app = _build_app()
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        results = [
+            _memory("mem_a", "x", agent_id="agent_abc", timestamp=now_iso),
+            _memory("mem_b", "y", agent_id="other_agent", timestamp=now_iso),
+        ]
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=results),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "q", "agent_id": "agent_abc"},
+        )
+
+        assert response.status_code == 200
+        ids = [m["memory_id"] for m in response.json()["memories"]]
+        assert ids == ["mem_a"]
+
+    def it_honors_limit(self, monkeypatch):
+        app = _build_app()
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        results = [
+            _memory(f"mem_{i}", "x", similarity=0.9 - 0.1 * i, timestamp=now_iso)
+            for i in range(8)
+        ]
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=results),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "q", "limit": 3},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["memories"]) == 3
+
+    def it_defaults_missing_importance_to_05(self, monkeypatch):
+        app = _build_app()
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        # Memory without importance in metadata (legacy agent-memory record).
+        legacy = _memory("mem_legacy", "x", timestamp=now_iso)
+        legacy["metadata"] = {}
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=[legacy]),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "q"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["memories"][0]["importance"] == 0.5
+
+    def it_accepts_custom_weights(self, monkeypatch):
+        app = _build_app()
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        results = [
+            _memory("mem_1", "x", similarity=0.9, importance=0.2, timestamp=now_iso),
+            _memory("mem_2", "y", similarity=0.5, importance=1.0, timestamp=now_iso),
+        ]
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=results),
+        )
+
+        client = TestClient(app)
+        # Importance weight dominates — mem_2 (importance=1.0) ranks first.
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={
+                "query": "q",
+                "weights": {
+                    "similarity": 0.1,
+                    "recency": 0.1,
+                    "importance": 0.8,
+                    "half_life_days": 7.0,
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        ids = [m["memory_id"] for m in response.json()["memories"]]
+        assert ids[0] == "mem_2"
+
+    def it_returns_empty_when_no_matches(self, monkeypatch):
+        app = _build_app()
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            AsyncMock(return_value=[]),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "q"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["memories"] == []
+        assert body["query"] == "q"
+
+    def it_passes_namespace_and_limit_to_service(self, monkeypatch):
+        app = _build_app()
+        captured: Dict[str, Any] = {}
+
+        async def _capture(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            "app.api.cognitive.recall.agent_memory_service.search_memories",
+            _capture,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/recall",
+            json={"query": "what", "namespace": "ns_test", "limit": 25},
+        )
+
+        assert response.status_code == 200
+        assert captured["project_id"] == DEFAULT_PID
+        assert captured["query"] == "what"
+        assert captured["namespace"] == "ns_test"
+        assert captured["top_k"] == 25
+
+
+class DescribeRecencyWeightDecay:
+    """Exponential recency decay: 0.5 ** (age_days / half_life_days)."""
+
+    def it_returns_1_for_now(self):
+        svc = CognitiveMemoryService()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+        ts = "2026-04-17T12:00:00Z"
+
+        assert svc.compute_recency_weight(ts, half_life_days=7.0, now=now) == pytest.approx(1.0)
+
+    def it_halves_at_half_life(self):
+        svc = CognitiveMemoryService()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+        seven_days_ago = (now - timedelta(days=7)).isoformat().replace("+00:00", "Z")
+
+        weight = svc.compute_recency_weight(seven_days_ago, half_life_days=7.0, now=now)
+
+        assert weight == pytest.approx(0.5, rel=0.01)
+
+    def it_quarter_at_two_half_lives(self):
+        svc = CognitiveMemoryService()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+        fourteen_days_ago = (now - timedelta(days=14)).isoformat().replace("+00:00", "Z")
+
+        weight = svc.compute_recency_weight(fourteen_days_ago, half_life_days=7.0, now=now)
+
+        assert weight == pytest.approx(0.25, rel=0.01)
+
+    def it_near_zero_for_very_old(self):
+        svc = CognitiveMemoryService()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+        ancient = (now - timedelta(days=365)).isoformat().replace("+00:00", "Z")
+
+        weight = svc.compute_recency_weight(ancient, half_life_days=7.0, now=now)
+
+        assert 0.0 <= weight < 0.001
+
+    def it_returns_1_for_none_timestamp(self):
+        svc = CognitiveMemoryService()
+
+        assert svc.compute_recency_weight(None) == 1.0
+
+    def it_returns_1_for_malformed_timestamp(self):
+        svc = CognitiveMemoryService()
+
+        assert svc.compute_recency_weight("not a timestamp") == 1.0
+
+    def it_supports_configurable_half_life(self):
+        svc = CognitiveMemoryService()
+        now = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
+        one_day_ago = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+
+        w_7d = svc.compute_recency_weight(one_day_ago, half_life_days=7.0, now=now)
+        w_1d = svc.compute_recency_weight(one_day_ago, half_life_days=1.0, now=now)
+
+        # Shorter half-life => faster decay => lower weight at same age
+        assert w_1d < w_7d
+
+
+class DescribeComposeRelevance:
+    """Weighted sum used by /recall to rank memories."""
+
+    def it_default_weights_sum_to_1(self):
+        w = RecallWeights()
+        assert w.similarity + w.recency + w.importance == pytest.approx(1.0)
+
+    def it_returns_weighted_sum(self):
+        svc = CognitiveMemoryService()
+        weights = RecallWeights(similarity=0.5, recency=0.25, importance=0.25, half_life_days=7.0)
+
+        score = svc.compose_relevance(
+            similarity=0.8, recency=0.4, importance=0.6, weights=weights
+        )
+
+        assert score == pytest.approx(0.8 * 0.5 + 0.4 * 0.25 + 0.6 * 0.25)


### PR DESCRIPTION
## Summary

- Implements `/memory/recall` with composite relevance scoring: similarity × w_sim + recency × w_rec + importance × w_imp.
- Recency uses exponential decay: `weight = 0.5 ** (age_days / half_life_days)`, configurable per-call.
- Legacy memory records without `importance` default to 0.5.
- Optional `agent_id` post-filter, default limit 10, max 100.

## Test plan

- [x] 16 tests in `test_cognitive_recall.py`
- [x] 54 passing total across cognitive suite
- [x] Ordering verified: high similarity first, custom weights can invert
- [x] Recency decay: 1.0 now, 0.5 at half-life, 0.25 at two half-lives, ~0 for very old
- [x] None/malformed timestamps → 1.0 (graceful fallback)
- [x] Empty results, limit, namespace, query all pass-through correctly

## Coverage

```
app/api/cognitive/recall.py                   44      6    86%
```

Closes #310
Refs #292

Built by AINative Dev Team