### PR TITLE
feat(cognitive-memory): implement POST /memory/reflect (S3)

### DIFF
--- a/backend/app/api/cognitive/reflect.py
+++ b/backend/app/api/cognitive/reflect.py
@@ -1,30 +1,84 @@
 """
 POST /v1/public/{project_id}/memory/reflect — cognitive reflect endpoint.
 
-Refs #292. S0 (#308) lands a 501 stub; S3 (#311) replaces with heuristic
-synthesis of patterns / contradictions / gaps.
+Refs #292, #311 (S3).
+
+Fetches an agent's memories within `window_days`, runs the deterministic
+insight heuristic (patterns, contradictions, gaps), and returns the
+report. Intended to be pluggable to LLM synthesis in a follow-up.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Path, status
 
 from app.schemas.cognitive_memory import ReflectRequest, ReflectResponse
+from app.services.agent_memory_service import agent_memory_service
+from app.services.cognitive_memory_service import get_cognitive_memory_service
 
 router = APIRouter(prefix="/v1/public", tags=["cognitive-memory"])
+
+
+def _within_window(
+    timestamp: Optional[str],
+    window_days: int,
+    now: Optional[datetime] = None,
+) -> bool:
+    """True if `timestamp` is within `window_days` of `now`.
+
+    Missing/unparseable timestamps are treated as in-window so legacy
+    records aren't silently dropped from reflection.
+    """
+    if not timestamp:
+        return True
+    ts_str = (
+        timestamp.replace("Z", "+00:00")
+        if timestamp.endswith("Z")
+        else timestamp
+    )
+    try:
+        parsed = datetime.fromisoformat(ts_str)
+    except (ValueError, TypeError):
+        return True
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    now_dt = now or datetime.now(timezone.utc)
+    cutoff = now_dt - timedelta(days=window_days)
+    return parsed >= cutoff
 
 
 @router.post(
     "/{project_id}/memory/reflect",
     response_model=ReflectResponse,
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+    status_code=status.HTTP_200_OK,
     summary="Reflect (synthesize patterns, contradictions, gaps)",
 )
-async def reflect(project_id: str, request: ReflectRequest) -> ReflectResponse:
-    """Placeholder until #311 lands the real handler."""
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail={
-            "error_code": "NOT_IMPLEMENTED",
-            "detail": "POST /memory/reflect not yet implemented (#311)",
-        },
+async def reflect(
+    request: ReflectRequest,
+    project_id: str = Path(..., min_length=1),
+) -> ReflectResponse:
+    """Synthesize an insight report over the agent's recent memories."""
+    memories, total, _filters = await agent_memory_service.list_memories(
+        project_id=project_id,
+        agent_id=request.agent_id,
+        namespace=request.namespace,
+        limit=500,
+    )
+
+    in_window: List[Dict[str, Any]] = [
+        m for m in memories if _within_window(m.get("timestamp"), request.window_days)
+    ]
+
+    cognitive = get_cognitive_memory_service()
+    insights = cognitive.synthesize_insights(in_window)
+
+    return ReflectResponse(
+        agent_id=request.agent_id,
+        window_days=request.window_days,
+        memory_count=total,
+        patterns=insights["patterns"],
+        contradictions=insights["contradictions"],
+        gaps=insights["gaps"],
     )

--- a/backend/app/services/cognitive_memory_service.py
+++ b/backend/app/services/cognitive_memory_service.py
@@ -199,23 +199,133 @@ class CognitiveMemoryService:
         )
 
     # ------------------------------------------------------------------
-    # Insight synthesis (real logic lands in S3)
+    # Insight synthesis (Refs #311 S3)
     # ------------------------------------------------------------------
+
+    # Categories we expect to see in any long-running agent's corpus;
+    # missing ones become `gaps`.
+    _EXPECTED_GAP_CATEGORIES = [
+        MemoryCategory.DECISION,
+        MemoryCategory.PLAN,
+        MemoryCategory.OBSERVATION,
+    ]
+
+    _APPROVE_TOKENS = ("approve", "approved", "accept", "ok'd", "yes")
+    _REJECT_TOKENS = ("reject", "rejected", "deny", "denied", "blocked")
+
+    # Tokens too generic to count as "shared topic" signal.
+    _STOPWORDS = frozenset({
+        "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "at",
+        "for", "with", "by", "from", "is", "are", "was", "were", "be", "been",
+        "being", "this", "that", "these", "those", "it", "its", "as", "if",
+        "then", "than", "so", "such", "not", "no", "yes", "do", "does", "did",
+        "have", "has", "had", "will", "would", "should", "could", "can", "may",
+        "might", "must", "up", "down", "out", "over", "under", "again", "also",
+    })
+
+    def _significant_tokens(self, text: str) -> set:
+        """Lowercased, non-stopword word set for naive topic comparison."""
+        tokens = set()
+        for raw in text.lower().split():
+            cleaned = "".join(ch for ch in raw if ch.isalnum())
+            if len(cleaned) < 3:
+                continue
+            if cleaned in self._STOPWORDS:
+                continue
+            tokens.add(cleaned)
+        return tokens
+
+    def _extract_category(self, memory: Dict[str, Any]) -> MemoryCategory:
+        """Pull the stored category from metadata; fall back to OTHER."""
+        metadata = memory.get("metadata", {}) or {}
+        raw = metadata.get("category")
+        if isinstance(raw, MemoryCategory):
+            return raw
+        try:
+            return MemoryCategory(raw)
+        except (ValueError, TypeError):
+            return MemoryCategory.OTHER
 
     def synthesize_insights(
         self,
         memories: List[Dict[str, Any]],
     ) -> Dict[str, List[Any]]:
         """
-        Return empty insights. Replaced in S3 (#311).
+        Deterministic heuristic synthesis.
 
-        Returns a dict with `patterns`, `contradictions`, `gaps` keys so the
-        endpoint layer has a consistent interface from S0 onward.
+        - `patterns`: top-3 most common categories across `memories`, sorted
+          by count desc. Label is the category's enum value.
+        - `contradictions`: pairs of memories where one contains an
+          approve-token and the other a reject-token AND they share at
+          least 2 significant (non-stopword) tokens — taken as a naive
+          "same topic" proxy.
+        - `gaps`: expected categories (`decision`, `plan`, `observation`)
+          absent from the corpus.
         """
+        # --- Patterns -------------------------------------------------
+        counts: Dict[MemoryCategory, int] = {}
+        for m in memories:
+            cat = self._extract_category(m)
+            counts[cat] = counts.get(cat, 0) + 1
+
+        patterns: List[InsightPattern] = [
+            InsightPattern(label=cat.value, count=n, category=cat)
+            for cat, n in sorted(
+                counts.items(), key=lambda kv: (-kv[1], kv[0].value)
+            )
+        ][:3]
+
+        # --- Contradictions ------------------------------------------
+        approves = []
+        rejects = []
+        for m in memories:
+            content_lower = (m.get("content") or "").lower()
+            if any(tok in content_lower for tok in self._APPROVE_TOKENS):
+                approves.append(m)
+            if any(tok in content_lower for tok in self._REJECT_TOKENS):
+                rejects.append(m)
+
+        contradictions: List[InsightContradiction] = []
+        seen_pairs = set()
+        for a in approves:
+            a_tokens = self._significant_tokens(a.get("content") or "")
+            for r in rejects:
+                if a.get("memory_id") == r.get("memory_id"):
+                    continue
+                r_tokens = self._significant_tokens(r.get("content") or "")
+                overlap = a_tokens & r_tokens
+                if len(overlap) < 2:
+                    continue
+                pair_key = frozenset({a.get("memory_id"), r.get("memory_id")})
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+                topic = " ".join(sorted(overlap)[:3])
+                contradictions.append(
+                    InsightContradiction(
+                        topic=topic,
+                        memory_ids=[a.get("memory_id", ""), r.get("memory_id", "")],
+                    )
+                )
+
+        # --- Gaps -----------------------------------------------------
+        present = {c for c, n in counts.items() if n > 0}
+        gaps: List[InsightGap] = []
+        for cat in self._EXPECTED_GAP_CATEGORIES:
+            if cat not in present:
+                gaps.append(
+                    InsightGap(
+                        category=cat,
+                        description=(
+                            f"No memories of category '{cat.value}' in the corpus"
+                        ),
+                    )
+                )
+
         return {
-            "patterns": [],  # type: List[InsightPattern]
-            "contradictions": [],  # type: List[InsightContradiction]
-            "gaps": [],  # type: List[InsightGap]
+            "patterns": patterns,
+            "contradictions": contradictions,
+            "gaps": gaps,
         }
 
     # ------------------------------------------------------------------

--- a/backend/app/tests/test_cognitive_memory_scaffold.py
+++ b/backend/app/tests/test_cognitive_memory_scaffold.py
@@ -47,22 +47,12 @@ def _build_app(workshop_mode: bool = False) -> FastAPI:
 
 
 class DescribeCognitiveMemoryStubs:
-    """Stubs for endpoints not yet implemented (S3, S4)."""
+    """Stubs for endpoints not yet implemented (S4)."""
 
     # /remember is implemented in S1 (#309); see test_cognitive_remember.py
     # /recall   is implemented in S2 (#310); see test_cognitive_recall.py
+    # /reflect  is implemented in S3 (#311); see test_cognitive_reflect.py
     # Remaining stubs below.
-
-    def it_reflect_returns_501(self):
-        app = _build_app()
-        client = TestClient(app)
-
-        response = client.post(
-            f"/v1/public/{DEFAULT_PID}/memory/reflect",
-            json={"agent_id": "agent_abc"},
-        )
-
-        assert response.status_code == 501
 
     def it_profile_returns_501(self):
         app = _build_app()
@@ -146,15 +136,8 @@ class DescribeWorkshopAliasRouting:
 
     # /api/v1/memory/remember routing covered by test_cognitive_remember.py
     # /api/v1/memory/recall   routing covered by test_cognitive_recall.py
+    # /api/v1/memory/reflect  routing covered by test_cognitive_reflect.py
     # Remaining stubs below.
-
-    def it_routes_api_v1_memory_reflect_to_stub(self):
-        app = _build_app(workshop_mode=True)
-        client = TestClient(app)
-
-        response = client.post("/api/v1/memory/reflect", json={})
-
-        assert response.status_code == 501
 
     def it_routes_api_v1_memory_profile_to_stub(self):
         app = _build_app(workshop_mode=True)
@@ -234,12 +217,15 @@ class DescribeCognitiveMemoryService:
 
         assert score == pytest.approx(0.8 * 0.5 + 0.6 * 0.5 + 0.9 * 0.0)
 
-    def it_synthesize_insights_returns_empty_buckets(self):
+    def it_synthesize_insights_returns_keyed_dict(self):
+        """S3 (#311) replaced the empty-buckets stub with a real heuristic."""
         svc = CognitiveMemoryService()
 
         insights = svc.synthesize_insights([])
 
-        assert insights == {"patterns": [], "contradictions": [], "gaps": []}
+        assert set(insights.keys()) == {"patterns", "contradictions", "gaps"}
+        assert insights["patterns"] == []
+        assert insights["contradictions"] == []
 
     def it_build_profile_with_empty_memories(self):
         svc = CognitiveMemoryService()

--- a/backend/app/tests/test_cognitive_reflect.py
+++ b/backend/app/tests/test_cognitive_reflect.py
@@ -1,0 +1,270 @@
+"""
+Tests for POST /v1/public/{project_id}/memory/reflect (Refs #292, #311).
+
+Covers:
+- End-to-end: handler fetches memories, calls synthesize_insights, returns
+  ReflectResponse.
+- Service: synthesize_insights patterns/contradictions/gaps heuristics.
+
+Heuristic summary:
+- patterns: top-3 most frequent MemoryCategory values by count
+- contradictions: pairs with "approve" vs "reject" keywords on shared
+  content tokens (>= 1 overlap on meaningful words)
+- gaps: expected categories (decision, plan, observation) with zero
+  memories in the corpus
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.cognitive_memory import router as cognitive_memory_router
+from app.schemas.cognitive_memory import MemoryCategory
+from app.services.cognitive_memory_service import CognitiveMemoryService
+
+DEFAULT_PID = "proj_test_s3"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(cognitive_memory_router)
+    return app
+
+
+def _memory(
+    memory_id: str,
+    content: str,
+    category: str = "other",
+    timestamp: str = "2026-04-17T00:00:00Z",
+    agent_id: str = "agent_abc",
+) -> Dict[str, Any]:
+    return {
+        "memory_id": memory_id,
+        "agent_id": agent_id,
+        "run_id": "run_1",
+        "memory_type": "episodic",
+        "content": content,
+        "metadata": {"category": category},
+        "namespace": "default",
+        "timestamp": timestamp,
+        "project_id": DEFAULT_PID,
+    }
+
+
+class DescribeReflectEndpoint:
+    """End-to-end /memory/reflect."""
+
+    def it_returns_memory_count_and_buckets(self, monkeypatch):
+        app = _build_app()
+        memories = [
+            _memory("m1", "Decided to approve TX-1", category="decision"),
+            _memory("m2", "Decided to approve TX-2", category="decision"),
+            _memory("m3", "Error: timeout", category="error"),
+        ]
+        monkeypatch.setattr(
+            "app.api.cognitive.reflect.agent_memory_service.list_memories",
+            AsyncMock(return_value=(memories, len(memories), {})),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/reflect",
+            json={"agent_id": "agent_abc", "window_days": 30},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["memory_count"] == 3
+        assert body["window_days"] == 30
+        assert isinstance(body["patterns"], list)
+        assert isinstance(body["contradictions"], list)
+        assert isinstance(body["gaps"], list)
+
+    def it_passes_agent_id_filter_to_list_memories(self, monkeypatch):
+        app = _build_app()
+        captured: Dict[str, Any] = {}
+
+        async def _capture(**kwargs):
+            captured.update(kwargs)
+            return ([], 0, {})
+
+        monkeypatch.setattr(
+            "app.api.cognitive.reflect.agent_memory_service.list_memories",
+            _capture,
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/reflect",
+            json={"agent_id": "agent_xyz", "namespace": "ns_a"},
+        )
+
+        assert response.status_code == 200
+        assert captured["project_id"] == DEFAULT_PID
+        assert captured["agent_id"] == "agent_xyz"
+        assert captured["namespace"] == "ns_a"
+
+    def it_returns_empty_buckets_on_empty_corpus(self, monkeypatch):
+        app = _build_app()
+        monkeypatch.setattr(
+            "app.api.cognitive.reflect.agent_memory_service.list_memories",
+            AsyncMock(return_value=([], 0, {})),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/reflect",
+            json={"agent_id": "agent_abc"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["memory_count"] == 0
+        assert body["patterns"] == []
+        assert body["contradictions"] == []
+        # Gaps present for all expected categories when corpus is empty
+        assert len(body["gaps"]) >= 1
+
+    def it_filters_to_window_days(self, monkeypatch):
+        app = _build_app()
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(days=5)).isoformat().replace("+00:00", "Z")
+        old = (now - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+
+        memories = [
+            _memory("m_recent", "x", category="decision", timestamp=recent),
+            _memory("m_old", "y", category="plan", timestamp=old),
+        ]
+        monkeypatch.setattr(
+            "app.api.cognitive.reflect.agent_memory_service.list_memories",
+            AsyncMock(return_value=(memories, 2, {})),
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            f"/v1/public/{DEFAULT_PID}/memory/reflect",
+            json={"agent_id": "agent_abc", "window_days": 30},
+        )
+
+        assert response.status_code == 200
+        # memory_count reflects pre-window total; patterns reflect window-filtered
+        body = response.json()
+        # Only the recent memory falls in the 30d window → patterns only show decision
+        labels = [p["label"] for p in body["patterns"]]
+        assert "decision" in labels
+        assert "plan" not in labels
+
+
+class DescribeSynthesizeInsightsPatterns:
+
+    def it_returns_top_categories_sorted_by_count(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "", category="decision"),
+            _memory("m2", "", category="decision"),
+            _memory("m3", "", category="plan"),
+            _memory("m4", "", category="decision"),
+            _memory("m5", "", category="observation"),
+        ]
+
+        result = svc.synthesize_insights(memories)
+        patterns = result["patterns"]
+
+        assert patterns[0].count == 3
+        assert patterns[0].category == MemoryCategory.DECISION
+
+    def it_returns_empty_patterns_on_empty_corpus(self):
+        svc = CognitiveMemoryService()
+
+        result = svc.synthesize_insights([])
+
+        assert result["patterns"] == []
+
+    def it_limits_patterns_to_top_3(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory(f"m{i}", "", category="decision") for i in range(4)
+        ] + [
+            _memory(f"p{i}", "", category="plan") for i in range(3)
+        ] + [
+            _memory(f"o{i}", "", category="observation") for i in range(2)
+        ] + [
+            _memory(f"e{i}", "", category="error") for i in range(1)
+        ] + [
+            _memory(f"i{i}", "", category="interaction") for i in range(1)
+        ]
+
+        result = svc.synthesize_insights(memories)
+
+        assert len(result["patterns"]) <= 3
+
+
+class DescribeSynthesizeInsightsContradictions:
+
+    def it_flags_approve_vs_reject_on_same_topic(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "Approved payment TX-123 to vendor Acme", category="decision"),
+            _memory("m2", "Rejected payment TX-123 to vendor Acme", category="decision"),
+        ]
+
+        result = svc.synthesize_insights(memories)
+        contradictions = result["contradictions"]
+
+        assert len(contradictions) == 1
+        ids = set(contradictions[0].memory_ids)
+        assert ids == {"m1", "m2"}
+
+    def it_no_contradiction_when_topics_differ(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "Approved TX-111 vendor Acme", category="decision"),
+            _memory("m2", "Rejected TX-999 vendor Globex", category="decision"),
+        ]
+
+        result = svc.synthesize_insights(memories)
+
+        assert result["contradictions"] == []
+
+    def it_no_contradiction_without_opposing_keywords(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "Observed a spike in rate limits", category="observation"),
+            _memory("m2", "Observed another spike in rate limits", category="observation"),
+        ]
+
+        result = svc.synthesize_insights(memories)
+
+        assert result["contradictions"] == []
+
+
+class DescribeSynthesizeInsightsGaps:
+
+    def it_flags_missing_expected_categories(self):
+        svc = CognitiveMemoryService()
+        # Only `observation` present; decision & plan are missing.
+        memories = [_memory("m1", "Noticed metric spike", category="observation")]
+
+        result = svc.synthesize_insights(memories)
+        gap_categories = [g.category for g in result["gaps"]]
+
+        assert MemoryCategory.DECISION in gap_categories
+        assert MemoryCategory.PLAN in gap_categories
+        assert MemoryCategory.OBSERVATION not in gap_categories
+
+    def it_no_gaps_when_all_expected_categories_present(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "", category="decision"),
+            _memory("m2", "", category="plan"),
+            _memory("m3", "", category="observation"),
+        ]
+
+        result = svc.synthesize_insights(memories)
+
+        assert result["gaps"] == []


### PR DESCRIPTION
## Summary

- Implements `/memory/reflect` with deterministic heuristic synthesis of **patterns / contradictions / gaps** from an agent's memory corpus.
- `window_days` filter applied client-side via ISO-8601 timestamp parsing (legacy records with missing/malformed timestamps are treated as in-window).
- Pluggable for future LLM-based synthesis — keep the heuristic as the free-tier / fallback path.

## Heuristics

- **Patterns**: top-3 MemoryCategory values by count, sorted desc.
- **Contradictions**: memory pairs where one contains an approve-token (`approve`, `approved`, `accept`, `ok'd`, `yes`) and another a reject-token (`reject`, `rejected`, `deny`, `denied`, `blocked`) AND they share ≥2 significant (non-stopword) content tokens.
- **Gaps**: decision / plan / observation categories absent from the corpus.

## Test plan

- [x] 12 tests in `test_cognitive_reflect.py` (4 endpoint + 3 patterns + 3 contradictions + 2 gaps)
- [x] 29 passing across scaffold + reflect
- [x] Empty corpus: empty patterns/contradictions, gaps list all expected categories
- [x] Window filter: 60-day-old memories excluded from 30-day window
- [x] Contradictions: approve/reject on same topic detected, differing topics ignored

Closes #311
Refs #292

Built by AINative Dev Team