### PR TITLE
feat(cognitive-memory): implement GET /memory/profile/{agent_id} (S4)

### DIFF
--- a/backend/app/api/cognitive/profile.py
+++ b/backend/app/api/cognitive/profile.py
@@ -1,14 +1,19 @@
 """
 GET /v1/public/{project_id}/memory/profile/{agent_id} — cognitive profile.
 
-Refs #292. S0 (#308) lands a 501 stub; S4 (#312) replaces with real
-profile building (topic distribution, expertise areas, etc.).
+Refs #292, #312 (S4).
+
+Fetches all memories for the agent (up to 500), delegates to
+CognitiveMemoryService.build_profile to compute stats, topics, expertise
+areas, and timeline boundaries.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Path, Query, status
 
 from app.schemas.cognitive_memory import ProfileResponse
+from app.services.agent_memory_service import agent_memory_service
+from app.services.cognitive_memory_service import get_cognitive_memory_service
 
 router = APIRouter(prefix="/v1/public", tags=["cognitive-memory"])
 
@@ -16,15 +21,21 @@ router = APIRouter(prefix="/v1/public", tags=["cognitive-memory"])
 @router.get(
     "/{project_id}/memory/profile/{agent_id}",
     response_model=ProfileResponse,
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+    status_code=status.HTTP_200_OK,
     summary="Cognitive profile (stats, topics, expertise)",
 )
-async def profile(project_id: str, agent_id: str) -> ProfileResponse:
-    """Placeholder until #312 lands the real handler."""
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail={
-            "error_code": "NOT_IMPLEMENTED",
-            "detail": "GET /memory/profile/{agent_id} not yet implemented (#312)",
-        },
+async def profile(
+    project_id: str = Path(..., min_length=1),
+    agent_id: str = Path(..., min_length=1),
+    namespace: str = Query(default="default", min_length=1),
+) -> ProfileResponse:
+    """Return the agent's cognitive profile."""
+    memories, _total, _filters = await agent_memory_service.list_memories(
+        project_id=project_id,
+        agent_id=agent_id,
+        namespace=namespace,
+        limit=500,
     )
+
+    cognitive = get_cognitive_memory_service()
+    return cognitive.build_profile(agent_id=agent_id, memories=memories)

--- a/backend/app/services/cognitive_memory_service.py
+++ b/backend/app/services/cognitive_memory_service.py
@@ -329,23 +329,98 @@ class CognitiveMemoryService:
         }
 
     # ------------------------------------------------------------------
-    # Profile building (real logic lands in S4)
+    # Profile building (Refs #312 S4)
     # ------------------------------------------------------------------
+
+    _PROFILE_TOPIC_LIMIT = 10
+    _EXPERTISE_AREA_LIMIT = 5
 
     def build_profile(
         self,
         agent_id: str,
         memories: List[Dict[str, Any]],
     ) -> ProfileResponse:
-        """Return a minimal profile. Replaced in S4 (#312)."""
+        """
+        Compute a cognitive profile from the agent's memory corpus.
+
+        - `categories`: ProfileCategoryStats per MemoryCategory that appears
+          in the corpus, sorted by count desc.
+        - `topics`: top N ProfileTopicCount entries by count, each with an
+          average-importance value. Topics are extracted via
+          `_significant_tokens` (non-stopword, length>=3).
+        - `expertise_areas`: top topics sorted by `count × avg_importance`,
+          capped at 5.
+        - `first_memory_at` / `last_memory_at`: min / max ISO timestamps.
+        """
+        if not memories:
+            return ProfileResponse(agent_id=agent_id, memory_count=0)
+
+        # Categories
+        cat_counts: Dict[MemoryCategory, int] = {}
+        # Topic aggregation: {token: (count, sum_importance)}
+        topic_agg: Dict[str, List[float]] = {}
+        timestamps: List[str] = []
+
+        for m in memories:
+            cat = self._extract_category(m)
+            cat_counts[cat] = cat_counts.get(cat, 0) + 1
+
+            metadata = m.get("metadata", {}) or {}
+            try:
+                importance = float(metadata.get("importance", 0.5))
+            except (TypeError, ValueError):
+                importance = 0.5
+
+            for token in self._significant_tokens(m.get("content") or ""):
+                bucket = topic_agg.setdefault(token, [0, 0.0])
+                bucket[0] += 1
+                bucket[1] += importance
+
+            ts = m.get("timestamp")
+            if isinstance(ts, str) and ts:
+                timestamps.append(ts)
+
+        categories = [
+            ProfileCategoryStats(category=cat, count=count)
+            for cat, count in sorted(
+                cat_counts.items(), key=lambda kv: (-kv[1], kv[0].value)
+            )
+        ]
+
+        topics = [
+            ProfileTopicCount(
+                topic=token,
+                count=count,
+                average_importance=max(0.0, min(1.0, total_imp / count)),
+            )
+            for token, (count, total_imp) in sorted(
+                topic_agg.items(), key=lambda kv: (-kv[1][0], kv[0])
+            )
+        ][: self._PROFILE_TOPIC_LIMIT]
+
+        # Expertise: rank by count × avg_importance
+        expertise_areas = [
+            token
+            for token, _score in sorted(
+                (
+                    (token, count * (total_imp / count))
+                    for token, (count, total_imp) in topic_agg.items()
+                ),
+                key=lambda kv: (-kv[1], kv[0]),
+            )
+        ][: self._EXPERTISE_AREA_LIMIT]
+
+        first_ts = min(timestamps) if timestamps else None
+        last_ts = max(timestamps) if timestamps else None
+
         return ProfileResponse(
             agent_id=agent_id,
             memory_count=len(memories),
-            categories=[],
-            topics=[],
-            expertise_areas=[],
-            first_memory_at=None,
-            last_memory_at=None,
+            categories=categories,
+            topics=topics,
+            expertise_areas=expertise_areas,
+            first_memory_at=first_ts,
+            last_memory_at=last_ts,
         )
 
 

--- a/backend/app/tests/test_cognitive_memory_scaffold.py
+++ b/backend/app/tests/test_cognitive_memory_scaffold.py
@@ -47,22 +47,12 @@ def _build_app(workshop_mode: bool = False) -> FastAPI:
 
 
 class DescribeCognitiveMemoryStubs:
-    """Stubs for endpoints not yet implemented (S4)."""
+    """All four endpoints now have real implementations (S1-S4)."""
 
     # /remember is implemented in S1 (#309); see test_cognitive_remember.py
     # /recall   is implemented in S2 (#310); see test_cognitive_recall.py
     # /reflect  is implemented in S3 (#311); see test_cognitive_reflect.py
-    # Remaining stubs below.
-
-    def it_profile_returns_501(self):
-        app = _build_app()
-        client = TestClient(app)
-
-        response = client.get(
-            f"/v1/public/{DEFAULT_PID}/memory/profile/agent_abc"
-        )
-
-        assert response.status_code == 501
+    # /profile  is implemented in S4 (#312); see test_cognitive_profile.py
 
 
 class DescribeCognitiveMemorySchemaValidation:
@@ -137,19 +127,12 @@ class DescribeWorkshopAliasRouting:
     # /api/v1/memory/remember routing covered by test_cognitive_remember.py
     # /api/v1/memory/recall   routing covered by test_cognitive_recall.py
     # /api/v1/memory/reflect  routing covered by test_cognitive_reflect.py
-    # Remaining stubs below.
-
-    def it_routes_api_v1_memory_profile_to_stub(self):
-        app = _build_app(workshop_mode=True)
-        client = TestClient(app)
-
-        response = client.get("/api/v1/memory/profile/agent_abc")
-
-        assert response.status_code == 501
+    # /api/v1/memory/profile  routing covered by test_cognitive_profile.py
 
 
 class DescribeCognitiveMemoryService:
-    """S0 service stubs return deterministic placeholders."""
+    """Low-level service smoke tests. Per-method behavior lives in the
+    S1–S4 endpoint test files."""
 
     def it_returns_singleton(self):
         s1 = get_cognitive_memory_service()

--- a/backend/app/tests/test_cognitive_profile.py
+++ b/backend/app/tests/test_cognitive_profile.py
@@ -1,0 +1,250 @@
+"""
+Tests for GET /v1/public/{project_id}/memory/profile/{agent_id}
+(Refs #292, #312).
+
+Covers:
+- End-to-end: handler fetches memories for the agent, calls
+  build_profile, returns ProfileResponse.
+- Service: build_profile — categories, topics, expertise areas,
+  first/last timestamps.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.cognitive_memory import router as cognitive_memory_router
+from app.schemas.cognitive_memory import MemoryCategory
+from app.services.cognitive_memory_service import CognitiveMemoryService
+
+DEFAULT_PID = "proj_test_s4"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(cognitive_memory_router)
+    return app
+
+
+def _memory(
+    memory_id: str,
+    content: str,
+    category: str = "other",
+    importance: float = 0.5,
+    timestamp: str = "2026-04-17T00:00:00Z",
+    agent_id: str = "agent_abc",
+) -> Dict[str, Any]:
+    return {
+        "memory_id": memory_id,
+        "agent_id": agent_id,
+        "run_id": "run_1",
+        "memory_type": "episodic",
+        "content": content,
+        "metadata": {"category": category, "importance": importance},
+        "namespace": "default",
+        "timestamp": timestamp,
+        "project_id": DEFAULT_PID,
+    }
+
+
+class DescribeProfileEndpoint:
+
+    def it_returns_profile_with_stats(self, monkeypatch):
+        app = _build_app()
+        memories = [
+            _memory("m1", "Approved payment", category="decision", timestamp="2026-04-10T00:00:00Z"),
+            _memory("m2", "Rejected plan", category="decision", timestamp="2026-04-12T00:00:00Z"),
+            _memory("m3", "Spike in traffic", category="observation", timestamp="2026-04-16T00:00:00Z"),
+        ]
+        monkeypatch.setattr(
+            "app.api.cognitive.profile.agent_memory_service.list_memories",
+            AsyncMock(return_value=(memories, 3, {})),
+        )
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/public/{DEFAULT_PID}/memory/profile/agent_abc"
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["agent_id"] == "agent_abc"
+        assert body["memory_count"] == 3
+        # Timestamps reflect min/max seen
+        assert body["first_memory_at"] == "2026-04-10T00:00:00Z"
+        assert body["last_memory_at"] == "2026-04-16T00:00:00Z"
+        # Categories include decision (2) and observation (1)
+        cat_map = {c["category"]: c["count"] for c in body["categories"]}
+        assert cat_map["decision"] == 2
+        assert cat_map["observation"] == 1
+
+    def it_passes_agent_id_filter_to_list_memories(self, monkeypatch):
+        app = _build_app()
+        captured: Dict[str, Any] = {}
+
+        async def _capture(**kwargs):
+            captured.update(kwargs)
+            return ([], 0, {})
+
+        monkeypatch.setattr(
+            "app.api.cognitive.profile.agent_memory_service.list_memories",
+            _capture,
+        )
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/public/{DEFAULT_PID}/memory/profile/agent_xyz"
+        )
+
+        assert response.status_code == 200
+        assert captured["project_id"] == DEFAULT_PID
+        assert captured["agent_id"] == "agent_xyz"
+
+    def it_returns_empty_profile_for_unknown_agent(self, monkeypatch):
+        app = _build_app()
+        monkeypatch.setattr(
+            "app.api.cognitive.profile.agent_memory_service.list_memories",
+            AsyncMock(return_value=([], 0, {})),
+        )
+
+        client = TestClient(app)
+        response = client.get(
+            f"/v1/public/{DEFAULT_PID}/memory/profile/nobody"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["agent_id"] == "nobody"
+        assert body["memory_count"] == 0
+        assert body["categories"] == []
+        assert body["topics"] == []
+        assert body["expertise_areas"] == []
+        assert body["first_memory_at"] is None
+        assert body["last_memory_at"] is None
+
+
+class DescribeBuildProfileCategories:
+
+    def it_counts_memories_per_category(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "", category="decision"),
+            _memory("m2", "", category="decision"),
+            _memory("m3", "", category="plan"),
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+
+        cat_map = {c.category: c.count for c in profile.categories}
+        assert cat_map[MemoryCategory.DECISION] == 2
+        assert cat_map[MemoryCategory.PLAN] == 1
+
+
+class DescribeBuildProfileTopics:
+
+    def it_extracts_topics_from_content_tokens(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "approved payment vendor acme invoice", importance=0.6),
+            _memory("m2", "rejected payment vendor acme refund", importance=0.4),
+            _memory("m3", "observed spike in payment gateway latency", importance=0.5),
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+        topic_counts = {t.topic: t.count for t in profile.topics}
+
+        # "payment" appears in all 3
+        assert topic_counts.get("payment") == 3
+        # "vendor" appears in 2
+        assert topic_counts.get("vendor") == 2
+        # Stopwords filtered
+        assert "in" not in topic_counts
+
+    def it_topic_average_importance_is_correct(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "payment approved", importance=1.0),
+            _memory("m2", "payment rejected", importance=0.0),
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+        by_topic = {t.topic: t for t in profile.topics}
+
+        # Payment's average importance = (1.0 + 0.0) / 2 = 0.5
+        assert by_topic["payment"].average_importance == pytest.approx(0.5)
+
+    def it_topics_sorted_by_count_desc(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory(f"m{i}", "payment approved", importance=0.5)
+            for i in range(5)
+        ] + [
+            _memory(f"p{i}", "plan migration", importance=0.5)
+            for i in range(2)
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+        topics = [t.topic for t in profile.topics]
+
+        # "payment" count 5 before anything with count 2
+        assert topics.index("payment") < topics.index("plan")
+
+
+class DescribeBuildProfileExpertise:
+
+    def it_returns_top_topics_by_count_times_importance(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            # High-expertise topic: 3 mentions × importance 0.9 = score 2.7
+            _memory("h1", "hedera", importance=0.9),
+            _memory("h2", "hedera", importance=0.9),
+            _memory("h3", "hedera", importance=0.9),
+            # Low-expertise topic: 5 mentions × importance 0.3 = score 1.5
+            _memory("mp1", "marketplace listing", importance=0.3),
+            _memory("mp2", "marketplace listing", importance=0.3),
+            _memory("mp3", "marketplace listing", importance=0.3),
+            _memory("mp4", "marketplace listing", importance=0.3),
+            _memory("mp5", "marketplace listing", importance=0.3),
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+
+        # hedera (score 2.7) ranks above marketplace/listing (score 1.5)
+        # despite lower count.
+        assert profile.expertise_areas[0] == "hedera"
+        assert profile.expertise_areas.index("hedera") < profile.expertise_areas.index("marketplace")
+
+    def it_returns_empty_expertise_for_empty_corpus(self):
+        svc = CognitiveMemoryService()
+
+        profile = svc.build_profile("agent_abc", [])
+
+        assert profile.expertise_areas == []
+
+
+class DescribeBuildProfileTimestamps:
+
+    def it_picks_min_and_max_timestamps(self):
+        svc = CognitiveMemoryService()
+        memories = [
+            _memory("m1", "x", timestamp="2026-04-10T00:00:00Z"),
+            _memory("m2", "y", timestamp="2026-04-01T00:00:00Z"),
+            _memory("m3", "z", timestamp="2026-04-15T00:00:00Z"),
+        ]
+
+        profile = svc.build_profile("agent_abc", memories)
+
+        assert profile.first_memory_at == "2026-04-01T00:00:00Z"
+        assert profile.last_memory_at == "2026-04-15T00:00:00Z"
+
+    def it_none_when_no_timestamps(self):
+        svc = CognitiveMemoryService()
+
+        profile = svc.build_profile("agent_abc", [])
+
+        assert profile.first_memory_at is None
+        assert profile.last_memory_at is None


### PR DESCRIPTION
## Summary

- Implements `/memory/profile/{agent_id}` with category stats, topic distribution, expertise areas, and timeline boundaries.
- **Expertise ranking**: `count × avg_importance` favors high-importance mastery over shallow repetition.
- Top-10 topics, top-5 expertise areas, categories sorted by count.

## Test plan

- [x] 11 tests in `test_cognitive_profile.py` (3 endpoint + 1 categories + 3 topics + 2 expertise + 2 timestamps)
- [x] 73 passing across full cognitive suite
- [x] Empty corpus: empty categories/topics/expertise, null timestamps
- [x] Topic aggregation: stopwords filtered, counts correct
- [x] Expertise: 3 high-importance mentions beat 5 low-importance mentions

## Coverage

```
app/api/cognitive/profile.py                  11      0   100%
```

Closes #312
Refs #292

Built by AINative Dev Team