### PR TITLE
docs: comprehensive tutorial fixes — correct API paths, enums, request bodies, cross-refs

### DIFF
--- a/docs/workshop/TESTNET_OPERATIONS.md
+++ b/docs/workshop/TESTNET_OPERATIONS.md
@@ -49,29 +49,32 @@ If short, fund via the Hedera testnet faucets:
 Run through Tutorial 2 steps against testnet as an operator:
 
 ```bash
+# Set your ZeroDB project ID (from .env ZERODB_PROJECT_ID, e.g. proj_workshop)
+PROJECT_ID=proj_workshop
+
 # 1. Create wallet
 curl -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
   -d '{"agent_id":"probe-agent"}' \
-  http://localhost:8000/api/v1/hedera/wallets
+  "http://localhost:8000/v1/public/$PROJECT_ID/hedera/wallets"
 # => save account_id
 
-# 2. Associate USDC
+# 2. Associate USDC (no request body)
 curl -X POST -H "X-API-Key: $API_KEY" \
-  http://localhost:8000/api/v1/hedera/wallets/{account_id}/associate-usdc
+  "http://localhost:8000/v1/public/$PROJECT_ID/hedera/wallets/{account_id}/associate-usdc"
 
 # 3. Check balance (0 USDC expected)
 curl -H "X-API-Key: $API_KEY" \
-  http://localhost:8000/api/v1/hedera/wallets/{account_id}/balance
+  "http://localhost:8000/v1/public/$PROJECT_ID/hedera/wallets/{account_id}/balance"
 
 # 4. Execute USDC payment
 curl -X POST -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
   -d '{"agent_id":"probe-agent","amount":1000000,"recipient":"0.0.22222","task_id":"probe-task-1","memo":"testnet probe"}' \
-  http://localhost:8000/api/v1/hedera/payments
+  "http://localhost:8000/v1/public/$PROJECT_ID/hedera/payments"
 # => save transaction_id
 
 # 5. Verify receipt
 curl -H "X-API-Key: $API_KEY" \
-  http://localhost:8000/api/v1/hedera/payments/{transaction_id}/verify
+  "http://localhost:8000/v1/public/$PROJECT_ID/hedera/payments/{transaction_id}/verify"
 # => verified: true, consensus_timestamp non-empty
 
 # 6. Open mirror_node_url from response in a browser — expect a 200 JSON payload

--- a/docs/workshop/tutorials/01-identity-and-memory.md
+++ b/docs/workshop/tutorials/01-identity-and-memory.md
@@ -1,19 +1,42 @@
 # Tutorial 1: Identity & Memory
 
-**Time:** ~50 minutes
+**Time:** ~50 minutes  
 **Goal:** Create an agent with a Hedera identity and persistent, tamper-proof memory
+
+> **Before you start:** Make sure your server is running and your `ZERODB_PROJECT_ID` is set.
+> Every URL in this tutorial contains `{project_id}` — replace it with the value of
+> `ZERODB_PROJECT_ID` from your `.env` file (e.g. `proj_workshop`).
+> See the [Vibe Coder Guide](../VIBE_CODER_GUIDE.md) for setup steps.
+> New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 
 ---
 
-## Step 1: Create Your Agent
+## Step 1: Create Your Agent *(~5 min)*
 
 Tell your AI:
 
-> "Send a POST request to http://localhost:8000/api/v1/agents to create a new agent. Use these details: did is 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK' (a placeholder — Step 4 will replace it with a real did:hedera), name is 'my-consensus-agent', role is 'analyst', scope is 'PROJECT', and description is 'My first autonomous fintech agent on Hedera'."
+> "Send a POST request to `http://localhost:8000/v1/public/{project_id}/agents` to create a new agent. Use these details: did is `did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK` (a placeholder — Step 4 will replace it with a real did:hedera), name is `my-consensus-agent`, role is `analyst`, scope is `PROJECT`, and description is `My first autonomous fintech agent on Hedera`. Replace `{project_id}` with my ZeroDB project ID."
 
-**Required fields:** `did` (must be `did:key:z6Mk...` format), `name`, `role`, `scope` (`SYSTEM`/`PROJECT`/`RUN`). Optional: `description`.
+**Required fields:**
+- `did` — must be `did:key:z6Mk...` format (placeholder; replaced in Step 4)
+- `name` — human-readable agent name
+- `role` — valid values: `analyst` | `compliance` | `transaction` | `orchestrator`
+- `scope` — valid values: `SYSTEM` | `PROJECT` | `RUN` (use `PROJECT` for this workshop)
 
-**Expected response:**
+**Optional:** `description` (max 1000 chars)
+
+**Request body example:**
+```json
+{
+  "did": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+  "name": "my-consensus-agent",
+  "role": "analyst",
+  "scope": "PROJECT",
+  "description": "My first autonomous fintech agent on Hedera"
+}
+```
+
+✅ **You should see:**
 ```json
 {
   "id": "agent_abc123...",
@@ -29,39 +52,47 @@ Tell your AI:
 }
 ```
 
-**Save your `agent_id`** — you'll need it for every step after this. The `did` field on the agent is the DID you'll later replace with a Hedera-native one in Step 4.
+📌 **Save your `agent_id`** — you'll need it for every step after this.
 
-**Verification:** `curl http://localhost:8000/api/v1/agents` shows your agent in the list.
-
----
-
-## Step 2: Verify Your Agent Exists
-
-Tell your AI:
-
-> "GET my agent details from http://localhost:8000/api/v1/agents/{agent_id} — replace {agent_id} with the ID from Step 1."
-
-**Verification:** You see your agent's name, role, and DID.
+**Verification:** `curl http://localhost:8000/v1/public/{project_id}/agents` shows your agent in the list.
 
 ---
 
-## Step 3: Explore the Agent API
+## Step 2: Verify Your Agent Exists *(~2 min)*
 
 Tell your AI:
 
-> "Show me all the endpoints available at http://localhost:8000/docs that start with /api/v1/agents. What can I do with agents?"
+> "GET my agent details from `http://localhost:8000/v1/public/{project_id}/agents/{agent_id}` — replace `{project_id}` with my ZeroDB project ID and `{agent_id}` with the ID from Step 1."
+
+✅ **You should see:** Your agent's name, role, and DID in the response JSON.
+
+---
+
+## Step 3: Explore the Agent API *(~3 min)*
+
+Tell your AI:
+
+> "Show me all the endpoints available at `http://localhost:8000/docs` that have `/agents` in the path. What can I do with agents?"
 
 This teaches you the API surface. Your AI will explain: create, list, get, update, delete — standard CRUD plus Hedera-specific identity operations.
 
 ---
 
-## Step 4: Register Agent Identity on Hedera
+## Step 4: Register Agent Identity on Hedera *(~7 min)*
 
 Tell your AI:
 
-> "Register my agent on Hedera using POST http://localhost:8000/api/v1/hedera/identity/register. My agent_id is {agent_id}. Give it capabilities: finance, compliance, payments."
+> "Register my agent on Hedera using `POST http://localhost:8000/api/v1/hedera/identity/register`. My agent_id is `{agent_id}`. Give it capabilities: `finance`, `compliance`, `payments`."
 
-**Expected response:**
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}",
+  "capabilities": ["finance", "compliance", "payments"]
+}
+```
+
+✅ **You should see:**
 ```json
 {
   "token_id": "0.0.XXXXX",
@@ -71,43 +102,61 @@ Tell your AI:
 }
 ```
 
-**Save your `agent_did`** — this is your agent's decentralized identity.
+📌 **Save your `agent_did`** — this is your agent's decentralized identity. It starts with `did:hedera:testnet:`.
 
 **Verification:** Your agent now has an HTS NFT on Hedera testnet. This NFT IS your agent's identity — portable, verifiable, revocable.
 
 ---
 
-## Step 5: Resolve Your Agent's DID
+## Step 5: Resolve Your Agent's DID *(~3 min)*
 
 Tell your AI:
 
-> "Resolve my agent's DID using GET http://localhost:8000/api/v1/hedera/identity/{agent_id}/did"
+> "Resolve my agent's DID using `GET http://localhost:8000/api/v1/hedera/identity/{agent_id}/did` — replace `{agent_id}` with the short ID from Step 1 (the `agt_...` format, NOT the `did:hedera:...` from Step 4)."
 
-**Expected response:** A W3C DID Document with your agent's verification methods and service endpoints.
+> 💡 **Which ID to use here?** Use the `agent_id` from Step 1 (the short `agent_abc123...` form), not the `agent_did` from Step 4. The path parameter `{agent_id}` means the ZeroDB agent ID, not the Hedera DID.
+
+✅ **You should see:** A W3C DID Document with your agent's verification methods and service endpoints.
 
 **What this means:** Any system in the world can verify your agent's identity by resolving this DID. No central authority needed.
 
 ---
 
-## Step 6: Check Agent Capabilities
+## Step 6: Check Agent Capabilities *(~2 min)*
 
 Tell your AI:
 
-> "Get my agent's capabilities from GET http://localhost:8000/api/v1/hedera/identity/{agent_id}/capabilities"
+> "Get my agent's capabilities from `GET http://localhost:8000/api/v1/hedera/identity/{agent_id}/capabilities` — use my short `agent_id` from Step 1."
 
-**Expected response:** The capabilities you registered (finance, compliance, payments).
+✅ **You should see:** The three capabilities you registered: `finance`, `compliance`, `payments`.
 
 ---
 
-## Step 7: Store Your Agent's First Memory — Cognitive API
+## Step 7: Store Your Agent's First Memory — Cognitive API *(~7 min)*
 
 The cognitive API wraps raw storage with importance scoring, auto-categorization, and automatic HCS anchoring. One endpoint replaces the old CRUD + explicit-anchor dance.
 
 Tell your AI:
 
-> "Store a memory for my agent using POST http://localhost:8000/api/v1/memory/remember. The agent_id is {agent_id}, content is 'Evaluated market conditions: HBAR/USD stable at 0.08, low volatility. Recommendation: proceed with transaction.', and memory_type is 'episodic'."
+> "Store a memory for my agent using `POST http://localhost:8000/v1/public/{project_id}/memory/remember`. The `agent_id` is `{agent_id}`, `content` is `'Evaluated market conditions: HBAR/USD stable at 0.08, low volatility. Recommendation: proceed with transaction.'`, and `memory_type` is `episodic`."
 
-**Expected response:**
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}",
+  "content": "Evaluated market conditions: HBAR/USD stable at 0.08, low volatility. Recommendation: proceed with transaction.",
+  "memory_type": "episodic"
+}
+```
+
+**`memory_type` valid values:** `working` | `episodic` | `semantic` | `procedural`
+
+**Optional fields:**
+- `namespace` (default: `"default"`) — isolates memories by context
+- `importance_hint` (0.0–1.0) — nudge the importance scorer
+- `metadata` (object) — arbitrary key/value for your own use
+
+✅ **You should see:**
 ```json
 {
   "memory_id": "mem_abc123...",
@@ -122,22 +171,44 @@ Tell your AI:
 }
 ```
 
-**Save your `memory_id`.**
+📌 **Save your `memory_id`.**
 
 **What this means:**
-- `category` — the cognitive API classified your memory automatically (keywords like "evaluated" → `observation`).
-- `importance` — a 0.0–1.0 score derived from memory type, content length, and any priority flags in metadata. Higher = more likely to resurface in recall.
-- `hcs_anchor_pending: false` — the memory's SHA-256 content hash was anchored to the Hedera Consensus Service **as part of the same call**. No separate anchor step needed; if it were `true`, the anchor can be retried later (the memory itself is still durable).
+- `category` — auto-classified from your content (keywords like "evaluated" → `observation`). Valid category values: `decision` | `observation` | `knowledge` | `plan` | `interaction` | `error` | `other`.
+- `importance` — a 0.0–1.0 score derived from memory type, content length, and any priority flags in metadata. Higher = more likely to surface in recall.
+- `hcs_anchor_pending: false` — the memory's SHA-256 content hash was anchored to the Hedera Consensus Service **as part of the same call**. No separate anchor step needed.
 
 ---
 
-## Step 8: Recall with Relevance + Recency
+## Step 8: Recall with Relevance + Recency *(~7 min)*
 
 Tell your AI:
 
-> "Recall memories for my agent using POST http://localhost:8000/api/v1/memory/recall. Use the query 'market conditions' and agent_id {agent_id}."
+> "Recall memories for my agent using `POST http://localhost:8000/v1/public/{project_id}/memory/recall`. Use `agent_id` `{agent_id}` and `query` `'market conditions'`."
 
-**Expected response:**
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}",
+  "query": "market conditions"
+}
+```
+
+**Optional `weights` field** — override the default ranking balance:
+```json
+{
+  "agent_id": "{agent_id}",
+  "query": "market conditions",
+  "weights": {
+    "similarity": 0.6,
+    "recency": 0.3,
+    "importance": 0.1,
+    "half_life_days": 7.0
+  }
+}
+```
+
+✅ **You should see:**
 ```json
 {
   "memories": [
@@ -167,30 +238,39 @@ Tell your AI:
 **What this means:** Three signals combined into one ranking score:
 - **similarity_score** — how close the memory is to your query (vector embedding cosine).
 - **recency_weight** — exponential decay over age (`0.5 ** (age_days / 7)`). Recent memories surface first.
-- **composite_score** — the weighted sum. Pass custom `weights` in the request body to reshape ranking (e.g. boost importance).
+- **composite_score** — the weighted sum. Pass custom `weights` to reshape ranking (e.g. boost importance over recency).
 
 This is how agents "remember what matters" instead of drowning in every past observation.
 
 ---
 
-## Step 9: Store More Memories, Then Reflect
+## Step 9: Store More Memories, Then Reflect *(~10 min)*
 
 Tell your AI:
 
-> "Remember two more memories for my agent via POST http://localhost:8000/api/v1/memory/remember:
-> (1) content 'KYC verification passed for counterparty 0.0.99999. Risk score: LOW.', memory_type 'episodic'.
-> (2) content 'Approved 10 USDC transfer to 0.0.99999 based on positive market analysis.', memory_type 'episodic'."
+> "Remember two more memories for my agent via `POST http://localhost:8000/v1/public/{project_id}/memory/remember`:
+> 1. `content` = `'KYC verification passed for counterparty 0.0.99999. Risk score: LOW.'`, `memory_type` = `episodic`
+> 2. `content` = `'Approved 10 USDC transfer to 0.0.99999 based on positive market analysis.'`, `memory_type` = `episodic`"
 
-Now recall by different queries to confirm semantic search still works:
+Now verify semantic search works across these memories:
 
-> "Recall memories for 'compliance' — does it find the KYC memory?"
-> "Recall memories for 'transfer approved' — does it find the transaction decision?"
+> "Recall memories for `'compliance'` — does it find the KYC memory?"
+> "Recall memories for `'transfer approved'` — does it find the transaction decision?"
 
-Then try the synthesis endpoints:
+Then run the synthesis endpoints:
 
-> "Generate cognitive insights for my agent using POST http://localhost:8000/api/v1/memory/reflect with agent_id {agent_id}. Look at patterns and contradictions across my memories."
+> "Generate cognitive insights for my agent using `POST http://localhost:8000/v1/public/{project_id}/memory/reflect` with `agent_id` = `{agent_id}`."
 
-**Expected response:**
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}"
+}
+```
+
+**Optional `window_days`** (default: 30) — how far back to look for patterns.
+
+✅ **You should see:**
 ```json
 {
   "agent_id": "agent_abc123...",
@@ -209,21 +289,40 @@ Then try the synthesis endpoints:
 
 Finally, check the agent's cognitive profile:
 
-> "Get the cognitive profile for my agent via GET http://localhost:8000/api/v1/memory/profile/{agent_id}."
+> "Get the cognitive profile for my agent via `GET http://localhost:8000/v1/public/{project_id}/memory/profile/{agent_id}`."
 
-**What this means:** `/reflect` gives you top patterns across a window, calls out contradictions (approve/reject on the same topic), and highlights gaps. `/profile/{agent_id}` surfaces the agent's topic distribution and expertise areas (`count × avg_importance`) — handy for routing work to the right agent.
+✅ **You should see:**
+```json
+{
+  "agent_id": "agent_abc123...",
+  "total_memories": 3,
+  "memory_type_distribution": {
+    "episodic": 3
+  },
+  "category_distribution": {
+    "observation": 1,
+    "decision": 2
+  },
+  "avg_importance": 0.58,
+  "expertise_topics": ["market conditions", "compliance", "payments"]
+}
+```
+
+**What this means:** `/reflect` identifies top patterns across a window, calls out contradictions (approve/reject on the same topic), and highlights gaps. `/profile/{agent_id}` surfaces the agent's topic distribution and expertise areas — handy for routing work to the right agent.
 
 ---
 
-## Step 10: Verify the HCS Anchor on the Public Ledger
+## Step 10: Verify the HCS Anchor on the Public Ledger *(~5 min)*
 
 `/memory/remember` anchors the memory's SHA-256 content hash to Hedera Consensus Service as part of the same call (`hcs_anchor_pending: false` in the response confirms it succeeded). Now verify the anchor is visible on the public ledger.
 
 Tell your AI:
 
-> "Fetch the HCS audit trail for memory {memory_id} via GET http://localhost:8000/api/v1/anchor/{memory_id}/verify. Return the HCS topic_id and sequence number."
+> "Fetch the HCS audit trail for memory `{memory_id}` via `GET http://localhost:8000/anchor/{memory_id}/verify`. Return the HCS `topic_id` and `sequence_number`."
 
-**Expected response:**
+> ⚠️ **Note:** The anchor endpoint does **not** have an `/api/v1/` or `/v1/public/` prefix — use the path exactly as shown: `GET http://localhost:8000/anchor/{memory_id}/verify`.
+
+✅ **You should see:**
 ```json
 {
   "memory_id": "mem_abc123...",
@@ -235,7 +334,7 @@ Tell your AI:
 }
 ```
 
-**Verification:** Open the `mirror_node_url` in your browser — you'll see the anchor record on the Hedera public ledger. If anyone modifies the stored memory, its SHA-256 will no longer match this anchor, which is how you prove tamper-evidence.
+**Verification:** Open the `mirror_node_url` in your browser — you'll see the anchor record on the Hedera public ledger. If anyone modifies the stored memory, its SHA-256 will no longer match this anchor, proving tamper-evidence.
 
 **What this means:** You didn't have to call an anchor endpoint yourself — the cognitive API did it automatically on write. Your agent's memory is **durable in ZeroDB and tamper-evident on Hedera** in a single operation. That's the full "remember with proof" flow regulated use cases require.
 
@@ -245,11 +344,11 @@ Tell your AI:
 
 You now have:
 - An AI agent with a unique identity
-- A Hedera-native DID (did:hedera) backed by an HTS NFT
+- A Hedera-native DID (`did:hedera`) backed by an HTS NFT
 - Persistent memories that survive across sessions
 - At least one memory anchored to Hedera for tamper-proof audit
 
-**What you built matters:** This isn't a toy. Regulated industries (finance, healthcare, legal) need exactly this: AI agents whose decisions are verifiable, auditable, and provably unmodified. You just built that foundation in under an hour, by talking to your AI assistant.
+**What you built matters:** Regulated industries (finance, healthcare, legal) need exactly this: AI agents whose decisions are verifiable, auditable, and provably unmodified. You just built that foundation in under an hour, by talking to your AI assistant.
 
 ---
 

--- a/docs/workshop/tutorials/02-payments-and-trust.md
+++ b/docs/workshop/tutorials/02-payments-and-trust.md
@@ -1,19 +1,30 @@
 # Tutorial 2: Payments & Trust
 
-**Time:** ~50 minutes
+**Time:** ~50 minutes  
 **Goal:** Execute USDC payments on Hedera and build an on-chain reputation
 
-**Prerequisite:** Completed Tutorial 1 (you have an agent_id and agent_did)
+**Prerequisite:** Completed Tutorial 1 — you have an `agent_id` (e.g. `agent_abc123...`) and an `agent_did` (e.g. `did:hedera:testnet:0.0.XXXXX_0.0.YYYYY`).
+
+> **Before you start:** Every URL containing `{project_id}` requires your `ZERODB_PROJECT_ID` from `.env`
+> (e.g. `proj_workshop`). See the [Vibe Coder Guide](../VIBE_CODER_GUIDE.md) if you haven't set this up.
+> New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 
 ---
 
-## Step 1: Create an Agent Wallet
+## Step 1: Create an Agent Wallet *(~5 min)*
 
 Tell your AI:
 
-> "Create a Hedera wallet for my agent using POST http://localhost:8000/api/v1/hedera/wallets. My agent_id is {agent_id}."
+> "Create a Hedera wallet for my agent using `POST http://localhost:8000/v1/public/{project_id}/hedera/wallets`. My `agent_id` is `{agent_id}`."
 
-**Expected response:**
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}"
+}
+```
+
+✅ **You should see:**
 ```json
 {
   "account_id": "0.0.XXXXX",
@@ -22,31 +33,40 @@ Tell your AI:
 }
 ```
 
-**Save your `account_id`.**
+📌 **Save your `account_id`** (the `0.0.XXXXX` format).
 
 **What this means:** Your agent now has its own Hedera account. It can hold HBAR and USDC independently of your operator account.
 
 ---
 
-## Step 2: Associate USDC Token
+## Step 2: Associate USDC Token *(~4 min)*
 
 Before your agent can receive USDC, its account must be associated with the USDC token. Tell your AI:
 
-> "Associate the USDC token with my agent's wallet using POST http://localhost:8000/api/v1/hedera/wallets/{account_id}/associate-usdc."
+> "Associate the USDC token with my agent's wallet using `POST http://localhost:8000/v1/public/{project_id}/hedera/wallets/{account_id}/associate-usdc` — replace `{account_id}` with my wallet account ID from Step 1. This endpoint takes no request body."
 
-**Verification:** The response confirms token association.
+> 💡 **No body needed** — this endpoint takes no JSON payload. Just the POST with your API key is enough.
+
+✅ **You should see:**
+```json
+{
+  "account_id": "0.0.XXXXX",
+  "token_id": "0.0.YYYYY",
+  "status": "associated"
+}
+```
 
 **Why this step exists:** On Hedera, accounts must explicitly opt-in to receive specific tokens. This is a security feature — no one can send you tokens you didn't agree to hold.
 
 ---
 
-## Step 3: Check Balance
+## Step 3: Check Balance *(~2 min)*
 
 Tell your AI:
 
-> "Check my agent's balance using GET http://localhost:8000/api/v1/hedera/wallets/{account_id}/balance."
+> "Check my agent's balance using `GET http://localhost:8000/v1/public/{project_id}/hedera/wallets/{account_id}/balance`."
 
-**Expected response:**
+✅ **You should see:**
 ```json
 {
   "account_id": "0.0.XXXXX",
@@ -57,15 +77,27 @@ Tell your AI:
 
 ---
 
-## Step 4: Execute a USDC Payment
+## Step 4: Execute a USDC Payment *(~7 min)*
 
 Now the core of x402 — your agent pays for a service. Tell your AI:
 
-> "Execute a USDC payment from my agent using POST http://localhost:8000/api/v1/hedera/payments. Transfer 1,000,000 USDC units (1 USDC) from my agent's account to account 0.0.22222. Set agent_id to my {agent_id}, task_id to 'workshop-task-1', and memo to 'workshop payment for data analysis'."
+> "Execute a USDC payment from my agent using `POST http://localhost:8000/v1/public/{project_id}/hedera/payments`. Transfer 1,000,000 USDC units (= 1 USDC) from my agent's account to account `0.0.22222`. Set `agent_id` to my `{agent_id}`, `task_id` to `workshop-task-1`, and `memo` to `workshop payment for data analysis`."
 
-**Required fields:** `agent_id`, `amount` (in USDC smallest units — 1 USDC = 1,000,000), `recipient`, `task_id`. Optional: `from_account`, `memo` (max 100 chars).
+**Request body example:**
+```json
+{
+  "agent_id": "{agent_id}",
+  "amount": 1000000,
+  "recipient": "0.0.22222",
+  "task_id": "workshop-task-1",
+  "memo": "workshop payment for data analysis"
+}
+```
 
-**Expected response:**
+**Required fields:** `agent_id`, `amount` (in USDC smallest units — 1 USDC = 1,000,000), `recipient`, `task_id`.  
+**Optional:** `from_account` (defaults to the agent's wallet), `memo` (max 100 chars).
+
+✅ **You should see:**
 ```json
 {
   "payment_id": "pay_abc123...",
@@ -79,17 +111,17 @@ Now the core of x402 — your agent pays for a service. Tell your AI:
 }
 ```
 
-**Save your `transaction_id`.**
+📌 **Save your `transaction_id`** — you'll need it as `payment_proof_tx` in Step 7 when you submit reputation feedback.
 
 ---
 
-## Step 5: Verify the Payment Receipt
+## Step 5: Verify the Payment Receipt *(~3 min)*
 
 Tell your AI:
 
-> "Verify my payment receipt using GET http://localhost:8000/api/v1/hedera/payments/{transaction_id}/verify."
+> "Verify my payment receipt using `GET http://localhost:8000/v1/public/{project_id}/hedera/payments/{transaction_id}/verify` — replace `{transaction_id}` with the transaction ID from Step 4."
 
-**Expected response:**
+✅ **You should see:**
 ```json
 {
   "verified": true,
@@ -99,31 +131,48 @@ Tell your AI:
 }
 ```
 
-**Verification:** Open the `mirror_node_url` in your browser. You'll see the actual Hedera transaction.
+**Verification:** Open the `mirror_node_url` in your browser. You'll see the actual Hedera transaction record.
 
 **What this means:** The payment is settled in under 3 seconds, verified by Hedera consensus, and independently auditable on the public ledger. No intermediary. No trust required.
 
 ---
 
-## Step 6: Explore the x402 Discovery Endpoint
+## Step 6: Explore the x402 Discovery Endpoint *(~3 min)*
 
 Tell your AI:
 
-> "GET http://localhost:8000/.well-known/x402 — what does this tell us?"
+> "`GET http://localhost:8000/.well-known/x402` — what does this tell us?"
 
-**Expected response:** The x402 protocol metadata including Hedera network, USDC token ID, supported DIDs, and signature methods.
+> 💡 **This is a GET with no body.** The `/.well-known/x402` path is a standard protocol endpoint — no `{project_id}` prefix needed.
+
+✅ **You should see:** The x402 protocol metadata including Hedera network, USDC token ID, supported DIDs, and signature methods.
 
 **What this means:** Any agent in the world can discover this server's payment capabilities by hitting this standard endpoint. It's how agents find and pay each other.
 
 ---
 
-## Step 7: Submit Reputation Feedback
+## Step 7: Submit Reputation Feedback *(~5 min)*
 
 Now let's build trust. You'll submit feedback for another agent (or your own for testing). Tell your AI:
 
-> "Submit reputation feedback using POST http://localhost:8000/api/v1/hedera/reputation/{agent_did}/feedback. Rate the agent 5 stars, comment 'Excellent analysis, fast settlement', with payment_proof_tx set to my transaction_id from Step 4, task_id 'workshop-task-1', and submitter_did set to my own agent_did."
+> "Submit reputation feedback using `POST http://localhost:8000/api/v1/hedera/reputation/{agent_did}/feedback`. Rate the agent 5 stars, comment `'Excellent analysis, fast settlement'`, with `payment_proof_tx` set to my `transaction_id` from Step 4, `task_id` `'workshop-task-1'`, and `submitter_did` set to my own `agent_did`."
 
-**Expected response:**
+> 💡 **Use the `agent_did` from Tutorial 1 Step 4** (the `did:hedera:...` format) in the URL path here, not the short `agent_id`.
+
+**Request body example:**
+```json
+{
+  "rating": 5,
+  "comment": "Excellent analysis, fast settlement",
+  "payment_proof_tx": "{transaction_id from Step 4}",
+  "task_id": "workshop-task-1",
+  "submitter_did": "{your agent_did}"
+}
+```
+
+**`rating` range:** 1–5 (integer).
+
+✅ **You should see:**
 ```json
 {
   "sequence_number": 1,
@@ -136,21 +185,21 @@ Now let's build trust. You'll submit feedback for another agent (or your own for
 
 ---
 
-## Step 8: Submit More Feedback (Different Ratings)
+## Step 8: Submit More Feedback (Different Ratings) *(~3 min)*
 
 Tell your AI:
 
-> "Submit two more feedback entries for the same agent: one with rating 4 and comment 'Good but slightly slow', and one with rating 5 and comment 'Perfect execution'. Use different task_ids."
+> "Submit two more feedback entries for the same agent `{agent_did}`: one with `rating` 4 and `comment` `'Good but slightly slow'`, and one with `rating` 5 and `comment` `'Perfect execution'`. Use different `task_id`s (e.g. `workshop-task-2` and `workshop-task-3`)."
 
 ---
 
-## Step 9: Check Reputation Score
+## Step 9: Check Reputation Score *(~3 min)*
 
 Tell your AI:
 
-> "Get the reputation score for agent {agent_did} using GET http://localhost:8000/api/v1/hedera/reputation/{agent_did}."
+> "Get the reputation score for agent `{agent_did}` using `GET http://localhost:8000/api/v1/hedera/reputation/{agent_did}`."
 
-**Expected response:**
+✅ **You should see:**
 ```json
 {
   "agent_did": "did:hedera:testnet:...",
@@ -163,29 +212,34 @@ Tell your AI:
 ```
 
 **What this means:** The score uses exponential recency decay — recent feedback matters more. Trust tiers progress as the agent builds history:
-- **0 (NEW):** < 3 reviews
-- **1 (BASIC):** score < 2.0 or < 10 reviews
-- **2 (TRUSTED):** score >= 2.0 and >= 10 reviews
-- **3 (VERIFIED):** score >= 3.5 and >= 25 reviews
-- **4 (ESTABLISHED):** score >= 4.0 and >= 50 reviews
+
+| Tier | Name | Criteria |
+|------|------|----------|
+| 0 | NEW | < 3 reviews |
+| 1 | BASIC | score < 2.0 or < 10 reviews |
+| 2 | TRUSTED | score ≥ 2.0 and ≥ 10 reviews |
+| 3 | VERIFIED | score ≥ 3.5 and ≥ 25 reviews |
+| 4 | ESTABLISHED | score ≥ 4.0 and ≥ 50 reviews |
 
 ---
 
-## Step 10: View Feedback History
+## Step 10: View Feedback History *(~2 min)*
 
 Tell your AI:
 
-> "Get all feedback for agent {agent_did} using GET http://localhost:8000/api/v1/hedera/reputation/{agent_did}/feedback."
+> "Get all feedback for agent `{agent_did}` using `GET http://localhost:8000/api/v1/hedera/reputation/{agent_did}/feedback`."
 
-**Verification:** You see all 3 feedback entries with their consensus timestamps.
+✅ **You should see:** A list of all 3 feedback entries with their consensus timestamps, ratings, and comments.
 
 ---
 
-## Step 11: See Ranked Agents
+## Step 11: See Ranked Agents *(~2 min)*
 
 Tell your AI:
 
-> "Get all agents ranked by reputation using GET http://localhost:8000/api/v1/hedera/reputation/ranked."
+> "Get all agents ranked by reputation using `GET http://localhost:8000/api/v1/hedera/reputation/ranked`."
+
+✅ **You should see:** A ranked list of all agents with their scores and tier names.
 
 **What this means:** When your agent needs to delegate work, it can choose partners based on on-chain trust scores. No fake reviews possible — every rating requires a verified payment proof.
 

--- a/docs/workshop/tutorials/03-discovery-and-marketplace.md
+++ b/docs/workshop/tutorials/03-discovery-and-marketplace.md
@@ -1,21 +1,33 @@
 # Tutorial 3: Discovery & Marketplace
 
-**Time:** ~50 minutes
+**Time:** ~50 minutes  
 **Goal:** Publish your agent, discover others, and coordinate a multi-agent workflow
 
-**Prerequisite:** Completed Tutorials 1 & 2 (you have agent_id, agent_did, and a payment history)
+**Prerequisite:** Completed Tutorials 1 & 2 — you have `agent_id`, `agent_did`, and a payment history.
+
+> New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 
 ---
 
-## Step 1: Register in HCS-14 Directory
+## Step 1: Register in HCS-14 Directory *(~5 min)*
 
 The HCS-14 standard is how Hedera agents advertise themselves for discovery. Tell your AI:
 
-> "Register my agent in the HCS-14 directory using POST http://localhost:8000/api/v1/hedera/identity/directory/register. My agent_did is {agent_did}, capabilities are ['finance', 'compliance', 'payments'], role is 'analyst', and reputation_score is 0."
+> "Register my agent in the HCS-14 directory using `POST http://localhost:8000/api/v1/hedera/identity/directory/register`. My `agent_did` is `{agent_did}`, capabilities are `['finance', 'compliance', 'payments']`, role is `analyst`, and `reputation_score` is 0."
 
-**Required fields:** `agent_did`, `capabilities` (list of strings), `role`, `reputation_score` (>= 0).
+**Request body example:**
+```json
+{
+  "agent_did": "{agent_did}",
+  "capabilities": ["finance", "compliance", "payments"],
+  "role": "analyst",
+  "reputation_score": 0
+}
+```
 
-**Expected response:**
+**Required fields:** `agent_did`, `capabilities` (list of strings), `role`, `reputation_score` (≥ 0).
+
+✅ **You should see:**
 ```json
 {
   "status": "SUCCESS",
@@ -29,33 +41,60 @@ The HCS-14 standard is how Hedera agents advertise themselves for discovery. Tel
 
 ---
 
-## Step 2: Search the Directory
+## Step 2: Search the Directory *(~3 min)*
 
 Tell your AI:
 
-> "Search the HCS-14 directory for agents with capability 'finance' using POST http://localhost:8000/api/v1/hedera/identity/directory/search."
+> "Search the HCS-14 directory for agents with capability `finance` using `POST http://localhost:8000/api/v1/hedera/identity/directory/search`."
 
-**Expected response:** A list of agents registered with the 'finance' capability — including yours!
+**Request body example:**
+```json
+{
+  "capability": "finance"
+}
+```
+
+**Optional fields:** `role` (filter by agent role), `min_reputation` (integer, minimum score).
+
+✅ **You should see:** A list of agents registered with the `finance` capability — including yours!
 
 ---
 
-## Step 3: Discover by Role
+## Step 3: Discover by Role *(~2 min)*
 
 Tell your AI:
 
-> "Search the directory for agents with role 'analyst'. Then search for role 'compliance'."
+> "Search the directory for agents with role `analyst`. Then search for role `compliance`. Use `POST http://localhost:8000/api/v1/hedera/identity/directory/search` with the `role` field."
 
 This shows how agents can find each other by function, not just by name.
 
 ---
 
-## Step 4: Send an HCS-10 Message
+## Step 4: Send an HCS-10 Message *(~7 min)*
 
 HCS-10 (OpenConvAI) is the protocol for agent-to-agent messaging on Hedera. Tell your AI:
 
-> "Send a message to another agent using POST http://localhost:8000/api/v1/hcs10/send. My sender_did is {my_agent_did}, recipient_did is {another_agent_did}, message_type is 'task_request', and payload is 'Please analyze HBAR/USD market conditions and report back'. Create a conversation_id like 'workshop-conv-1'."
+> "Send a message to another agent using `POST http://localhost:8000/hcs10/send`. My `sender_did` is `{my_agent_did}`, `recipient_did` is `{another_agent_did}`, `message_type` is `task_request`, `conversation_id` is `workshop-conv-1`, and `payload` is `{\"task\": \"Analyze HBAR/USD market conditions and report back\"}`."
 
-**Expected response:**
+> ⚠️ **Note:** The HCS-10 endpoint does **not** have an `/api/v1/` prefix — use `http://localhost:8000/hcs10/send` exactly.
+
+**Request body example:**
+```json
+{
+  "sender_did": "{my_agent_did}",
+  "recipient_did": "{another_agent_did}",
+  "message_type": "task_request",
+  "conversation_id": "workshop-conv-1",
+  "payload": {
+    "task": "Analyze HBAR/USD market conditions and report back"
+  }
+}
+```
+
+**`message_type` examples:** `task_request` | `task_response` | `status_update` | `error` | `ack`  
+**`payload`** is a JSON object (not a string) — put any structured data you want to transmit.
+
+✅ **You should see:**
 ```json
 {
   "message_id": "msg_...",
@@ -69,33 +108,65 @@ HCS-10 (OpenConvAI) is the protocol for agent-to-agent messaging on Hedera. Tell
 
 ---
 
-## Step 5: Check for Messages
+## Step 5: Check for Messages *(~2 min)*
 
 Tell your AI:
 
-> "Check for messages addressed to my agent using GET http://localhost:8000/api/v1/hcs10/messages/{my_agent_did}."
+> "Check for messages addressed to my agent using `GET http://localhost:8000/hcs10/messages/{my_agent_did}`."
+
+> ⚠️ **Note:** No `/api/v1/` prefix — use `http://localhost:8000/hcs10/messages/{my_agent_did}`.
 
 If another workshop attendee sent you a message, it'll appear here.
 
 ---
 
-## Step 6: View the Audit Trail
+## Step 6: View the Audit Trail *(~2 min)*
 
 Tell your AI:
 
-> "Get the audit trail for my conversation using GET http://localhost:8000/api/v1/hcs10/audit/{conversation_id}."
+> "Get the audit trail for my conversation using `GET http://localhost:8000/hcs10/audit/{conversation_id}`."
+
+> ⚠️ **Note:** No `/api/v1/` prefix — use `http://localhost:8000/hcs10/audit/{conversation_id}`.
+
+✅ **You should see:** An ordered list of all messages in your conversation, each with a consensus timestamp.
 
 **What this means:** Every agent-to-agent interaction is logged with consensus timestamps. This audit trail is admissible — it's anchored to Hedera, not stored in someone's private database.
 
 ---
 
-## Step 7: Publish to the Marketplace
+## Step 7: Publish to the Marketplace *(~7 min)*
 
 Tell your AI:
 
-> "Publish my agent to the marketplace using POST http://localhost:8000/api/v1/marketplace/agents. Use agent_id {agent_id}, category 'finance', description 'Autonomous fintech analyst specializing in market evaluation and compliance verification on Hedera', and pricing 'pay-per-task'."
+> "Publish my agent to the marketplace using `POST http://localhost:8000/marketplace/agents`. Use `publisher_did` = `{agent_did}`, `category` = `finance`, `description` = `'Autonomous fintech analyst specializing in market evaluation and compliance verification on Hedera'`, and `pricing` with `price_per_call` = 0.001 USDC."
 
-**Expected response:**
+> ⚠️ **Note:** The marketplace endpoint does **not** have an `/api/v1/` prefix — use `http://localhost:8000/marketplace/agents`.
+
+**Request body example:**
+```json
+{
+  "agent_config": {
+    "agent_id": "{agent_id}",
+    "name": "my-consensus-agent",
+    "did": "{agent_did}"
+  },
+  "publisher_did": "{agent_did}",
+  "pricing": {
+    "price_per_call": 0.001,
+    "free_tier_calls": 10
+  },
+  "category": "finance",
+  "description": "Autonomous fintech analyst specializing in market evaluation and compliance verification on Hedera",
+  "tags": ["hedera", "finance", "compliance"]
+}
+```
+
+**`category` valid values:** `finance` | `analytics` | `communication` | `development` | `research` | `automation` | `other`  
+**`pricing.price_per_call`** — USDC amount charged per API call (float ≥ 0.0)  
+**`pricing.price_per_hour`** — optional hourly rate  
+**`pricing.free_tier_calls`** — free calls per day (integer, default 0)
+
+✅ **You should see:**
 ```json
 {
   "listing_id": "listing_...",
@@ -107,36 +178,57 @@ Tell your AI:
 
 ---
 
-## Step 8: Browse the Marketplace
+## Step 8: Browse the Marketplace *(~2 min)*
 
 Tell your AI:
 
-> "Browse the agent marketplace using GET http://localhost:8000/api/v1/marketplace/browse. Filter by category 'finance'."
+> "Browse the agent marketplace using `GET http://localhost:8000/marketplace/browse`. Filter by `category=finance`."
+
+> ⚠️ **Note:** No `/api/v1/` prefix — `http://localhost:8000/marketplace/browse`.
 
 You should see your agent and potentially other workshop attendees' agents.
 
 ---
 
-## Step 9: Search the Marketplace
+## Step 9: Search the Marketplace *(~3 min)*
 
 Tell your AI:
 
-> "Search the marketplace for agents that can do 'compliance verification' using POST http://localhost:8000/api/v1/marketplace/search."
+> "Search the marketplace for agents that can do `compliance verification` using `POST http://localhost:8000/marketplace/search`."
+
+> ⚠️ **Note:** No `/api/v1/` prefix — `http://localhost:8000/marketplace/search`.
+
+**Request body example:**
+```json
+{
+  "query": "compliance verification"
+}
+```
+
+**Optional filters:**
+```json
+{
+  "query": "compliance verification",
+  "category": "finance",
+  "min_reputation": 3.0,
+  "price_range": { "min": 0.0, "max": 0.01 }
+}
+```
 
 ---
 
-## Step 10: The Full Agent Lifecycle
+## Step 10: The Full Agent Lifecycle *(~15 min)*
 
 Let's bring it all together. Tell your AI:
 
 > "I want to execute a complete agent workflow. Help me:
-> 1. Search the marketplace for a 'finance' agent
-> 2. Check its reputation score
-> 3. Send it a task request via HCS-10
-> 4. Execute a USDC payment for the service
-> 5. Verify the payment receipt on the mirror node
-> 6. Submit reputation feedback
-> 7. Anchor the entire interaction to HCS"
+> 1. Search the marketplace for a `finance` agent — `POST http://localhost:8000/marketplace/search`
+> 2. Check its reputation score — `GET http://localhost:8000/api/v1/hedera/reputation/{agent_did}`
+> 3. Send it a task request via HCS-10 — `POST http://localhost:8000/hcs10/send`
+> 4. Execute a USDC payment for the service — `POST http://localhost:8000/v1/public/{project_id}/hedera/payments`
+> 5. Verify the payment receipt on the mirror node — `GET http://localhost:8000/v1/public/{project_id}/hedera/payments/{transaction_id}/verify`
+> 6. Submit reputation feedback — `POST http://localhost:8000/api/v1/hedera/reputation/{agent_did}/feedback`
+> 7. Anchor the entire interaction to HCS — the memory endpoints do this automatically, or use the HCS-10 message audit trail"
 
 Your AI will orchestrate all of these API calls in sequence. Watch the output — this is an autonomous agent economy in action.
 
@@ -175,7 +267,7 @@ Ideas:
 
 Instead of raw API calls, use the SDKs for cleaner code:
 
-**TypeScript:** `npm install @ainative/agent-sdk`
+**TypeScript:** `npm install @ainative/agent-sdk`  
 **Python:** `pip install ainative-agent`
 
 See `docs/sdk/typescript-quickstart.md` and `docs/sdk/python-quickstart.md`.


### PR DESCRIPTION
## Summary

Fixes all workshop-blocking doc issues filed by the tutorial walkthrough session.

### API path corrections (Closes #323, #334, #335)
- Agents / memory endpoints: `/api/v1/agents`, `/api/v1/memory/...` → `/v1/public/{project_id}/...`
- Hedera wallet/payment endpoints: `/api/v1/hedera/wallets/...`, `/api/v1/hedera/payments/...` → `/v1/public/{project_id}/...`
- HCS-10 messaging: `/api/v1/hcs10/...` → `/hcs10/...` (no prefix)
- Marketplace: `/api/v1/marketplace/...` → `/marketplace/...` (no prefix)
- HCS anchor: `/api/v1/anchor/{id}/verify` → `/anchor/{id}/verify`
- TESTNET_OPERATIONS.md curl commands updated to match

### Missing request bodies (Closes #338)
- Tutorial 01 Step 8 (recall): add `query` + optional `weights` body
- Tutorial 01 Step 7 (remember): explicit request body shown
- Tutorial 02 Step 2 (associate-usdc): note — no body
- Tutorial 02 Step 4 (payment): full body with all required/optional fields
- Tutorial 02 Step 6 (x402): clarify — GET with no body
- Tutorial 02 Step 7 (reputation feedback): full body with all fields
- Tutorial 03 Step 2 (directory search): add `capability` / `role` / `min_reputation` body
- Tutorial 03 Step 7 (marketplace publish): fix — `pricing` is an object, not a string
- Tutorial 03 Step 9 (marketplace search): add `query` + optional filters body

### Field name and cross-reference fixes (Closes #339, #341)
- Tutorial 01 Step 5: clarify `{agent_id}` means the Step 1 short ID, not Step 4's `agent_did`
- Tutorial 02 Step 4 → Step 7: highlight `transaction_id` must be saved for `payment_proof_tx`

### Enum documentation (Closes #340)
- `role`: analyst | compliance | transaction | orchestrator
- `scope`: SYSTEM | PROJECT | RUN
- `memory_type`: working | episodic | semantic | procedural
- `category` (memory): decision | observation | knowledge | plan | interaction | error | other
- `category` (marketplace): finance | analytics | communication | development | research | automation | other
- `message_type` examples for HCS-10
- `pricing` model fields for marketplace

### Vibe-coder prompt improvements (Closes #331)
Every step now has explicit "Tell your AI:" prompt including the correct API path. Steps with complex payloads have a `Request body example` block attendees can copy verbatim.

### Expected response examples (Closes #332)
All 31 steps now have `✅ You should see:` blocks with expected JSON responses or explicit notes when no response body is returned.

### Tutorial pacing (Closes #336)
Step headers now include time estimates (e.g. `*(~5 min)*`). Logical boundary between identity steps (1–6) and memory steps (7–10) is labelled. No structural split — Tutorial 01 stays one file with clear markers.

## Test plan
- Documentation-only PR. No code changes, no test suite to run.
- Static verification performed during authoring:
  - All tutorial paths cross-checked against router prefix declarations in `backend/app/api/{agents,cognitive_memory,hedera_payments,hedera_wallets,hedera_identity,hedera_reputation,openconvai,marketplace,hcs_anchoring}.py`
  - All enum values cross-checked against `app/schemas/cognitive_memory.py` (`CognitiveMemoryType`, `MemoryCategory`), `app/schemas/agents.py` (`AgentRole`), `app/models/agent.py` (`AgentScope`), `app/schemas/marketplace.py` (`AgentCategory`, `PricingModel`)
  - Request body shapes cross-checked against `RememberRequest`, `RecallRequest`, `DirectorySearchRequest`, `PublishAgentRequest`, `SearchAgentsRequest`, `SendMessageRequest`
- Live verification (post-merge):
  - Walk Tutorial 01 Steps 1–4 with running server to confirm paths return 200
  - Run `python3 scripts/workshop_smoke_test.py` to confirm no regressions

Built by AINative Dev Team