### PR TITLE
fix(workshop): orchestrator project setup + Hedera wallets in T02 (Closes #330 #329)

### DIFF
--- a/scripts/workshop_e2e_test.py
+++ b/scripts/workshop_e2e_test.py
@@ -47,7 +47,11 @@ except ImportError:
 
 # Configuration
 BASE_URL = os.environ.get("WORKSHOP_BASE_URL", "http://localhost:8000")
-PROJECT_ID = os.environ.get("WORKSHOP_PROJECT_ID", "proj_test_change_in_production")
+# Default to an existing deterministic demo project owned by user_1 (demo_key_user1_abc123).
+# The previous default ("proj_test_change_in_production") did not exist in the project store,
+# which caused every project-scoped endpoint to 404. See issue #330.
+DEFAULT_PROJECT_ID = "proj_demo_u1_001"
+PROJECT_ID = os.environ.get("WORKSHOP_PROJECT_ID", DEFAULT_PROJECT_ID)
 API_KEY = os.environ.get("WORKSHOP_API_KEY", "demo_key_user1_abc123")
 SERVER_STARTUP_TIMEOUT = 30  # seconds
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -273,25 +277,32 @@ def api_get(path: str, expected_status: int = 200) -> Tuple[bool, Any, str]:
 # ---------------------------------------------------------------------------
 
 
-def ensure_project_exists() -> bool:
-    """Create the test project if it doesn't exist. Returns True if usable."""
-    # Try to get the project first
-    ok, data, detail = api_get(f"/v1/public/projects/{PROJECT_ID}")
-    if ok:
-        return True
-    # Try to create it
-    ok, data, detail = api_post(
-        "/v1/public/projects",
-        {
-            "project_id": PROJECT_ID,
-            "name": "Workshop Test Project",
-            "description": "E2E test project for workshop orchestrator",
-            "tier": "free",
-            "database_enabled": True,
-        },
-        expected_status=201,
+def ensure_project_exists() -> Tuple[bool, str]:
+    """
+    Verify the configured PROJECT_ID is reachable for the current API key.
+
+    Agent-402 uses a deterministic project store (see app/services/project_store.py)
+    and does not expose POST /v1/public/projects to create projects at runtime.
+    Workshop mode also does not auto-provision new projects. So the orchestrator
+    verifies the project is listed for the authenticated user and fails fast with
+    a helpful message otherwise.
+
+    Returns (ok, detail).
+    """
+    ok, data, detail = api_get("/v1/public/projects")
+    if not ok:
+        return False, f"Could not list projects: {detail}"
+    if not isinstance(data, dict):
+        return False, f"Unexpected projects list shape: {str(data)[:200]}"
+    projects = data.get("projects") or []
+    ids = {p.get("id") for p in projects if isinstance(p, dict)}
+    if PROJECT_ID in ids:
+        return True, ""
+    return False, (
+        f"project '{PROJECT_ID}' is not visible to API key. "
+        f"Visible projects: {sorted(i for i in ids if i)}. "
+        "Override with --project-id or WORKSHOP_PROJECT_ID."
     )
-    return ok
 
 
 def run_tutorial_01(result: TestResult, persona: str) -> None:
@@ -307,9 +318,13 @@ def run_tutorial_01(result: TestResult, persona: str) -> None:
         say("Server not responding properly. Cannot continue.")
         return
 
-    # Setup: ensure test project exists
-    say("Ensuring test project exists (setup)")
-    ensure_project_exists()
+    # Setup: verify test project is reachable
+    say(f"Verifying test project '{PROJECT_ID}' is reachable")
+    proj_ok, proj_detail = ensure_project_exists()
+    if not proj_ok:
+        checkpoint(False, "Test project reachable", proj_detail)
+        result.record(0, "Test project reachable", False, proj_detail, 0.0)
+        return
 
     if persona == "vibe-coder":
         prompt_as_vibe_coder(
@@ -480,34 +495,107 @@ def run_tutorial_01(result: TestResult, persona: str) -> None:
 def run_tutorial_02(result: TestResult, persona: str) -> None:
     banner("Tutorial 02: Payments & Trust")
 
-    # Step 1: Create wallet (Circle is the simpler test path)
-    step(1, "Create Circle wallet for agent")
+    # Tutorial 02 teaches Hedera wallets (not Circle). See docs/workshop/tutorials/02-payments-and-trust.md
+    # and issue #329. Circle wallet coverage lives in Tutorial 04 (both products are supported).
+
+    agent_id_for_wallet = "workshop-t02-agent"
+
+    # Step 1: Create Hedera wallet
+    step(1, "Create Hedera wallet for agent")
+    if persona == "vibe-coder":
+        prompt_as_vibe_coder(
+            "Create a Hedera wallet for my agent using "
+            "POST /v1/public/{project_id}/hedera/wallets with agent_id 'workshop-t02-agent'"
+        )
     t0 = time.time()
     ok, data, detail = api_post(
-        f"/v1/public/{PROJECT_ID}/circle/wallets",
+        f"/v1/public/{PROJECT_ID}/hedera/wallets",
         {
-            "agent_did": "did:key:z6MkWorkshopTest001",
-            "wallet_type": "EOA",
-            "blockchain": "ARC-TESTNET",
-            "description": "Workshop test wallet",
+            "agent_id": agent_id_for_wallet,
+            "initial_balance": 0,
         },
         expected_status=201,
     )
-    wallet_id = None
+    account_id: Optional[str] = None
     if ok and isinstance(data, dict):
-        wallet_id = data.get("wallet_id") or data.get("id")
-    passed = checkpoint(ok, "Circle wallet created", detail)
-    result.record(1, "Create wallet", passed, detail or f"wallet_id={wallet_id}", time.time() - t0)
+        account_id = data.get("account_id")
+    passed = checkpoint(
+        ok and account_id is not None,
+        "Hedera wallet created",
+        detail or f"account_id={account_id}",
+    )
+    result.record(1, "Create Hedera wallet", passed, detail or f"account_id={account_id}", time.time() - t0)
 
-    # Step 2: List wallets
-    step(2, "List Circle wallets")
+    # Step 2: Associate USDC with the Hedera account (required before USDC receipt)
+    step(2, "Associate USDC token with Hedera account")
+    if persona == "vibe-coder":
+        prompt_as_vibe_coder(
+            "Associate the USDC token with my wallet using "
+            "POST /v1/public/{project_id}/hedera/wallets/{account_id}/associate-usdc"
+        )
     t0 = time.time()
-    ok, data, detail = api_get(f"/v1/public/{PROJECT_ID}/circle/wallets")
-    passed = checkpoint(ok, "Wallets listable", detail)
-    result.record(2, "List wallets", passed, detail, time.time() - t0)
+    if account_id:
+        ok, data, detail = api_post(
+            f"/v1/public/{PROJECT_ID}/hedera/wallets/{account_id}/associate-usdc",
+            {},
+            expected_status=200,
+        )
+    else:
+        ok, data, detail = False, None, "No account_id from Step 1"
+    passed = checkpoint(ok, "USDC token associated", detail)
+    result.record(2, "Associate USDC", passed, detail, time.time() - t0)
 
-    # Step 3: x402 discovery
-    step(3, "Check x402 discovery for Hedera metadata")
+    # Step 2b: Get wallet balance (HBAR + USDC)
+    step(3, "Get Hedera wallet balance (HBAR + USDC)")
+    t0 = time.time()
+    if account_id:
+        ok, data, detail = api_get(
+            f"/v1/public/{PROJECT_ID}/hedera/wallets/{account_id}/balance"
+        )
+    else:
+        ok, data, detail = False, None, "No account_id from Step 1"
+    passed = checkpoint(ok, "Wallet balance retrievable", detail)
+    result.record(3, "Get wallet balance", passed, detail, time.time() - t0)
+
+    # Step 2c: Execute a USDC payment via HTS
+    step(4, "Execute USDC payment via Hedera HTS")
+    if persona == "vibe-coder":
+        prompt_as_vibe_coder(
+            "Send a USDC payment using POST /v1/public/{project_id}/hedera/payments "
+            "with amount 1000000 (1 USDC) to recipient 0.0.22222"
+        )
+    t0 = time.time()
+    ok, data, detail = api_post(
+        f"/v1/public/{PROJECT_ID}/hedera/payments",
+        {
+            "agent_id": agent_id_for_wallet,
+            "amount": 1_000_000,  # 1 USDC in smallest unit
+            "recipient": "0.0.22222",
+            "task_id": "workshop-t02-task",
+            "memo": "Workshop E2E payment test",
+        },
+        expected_status=201,
+    )
+    payment_tx_id: Optional[str] = None
+    if ok and isinstance(data, dict):
+        payment_tx_id = data.get("transaction_id")
+    passed = checkpoint(ok, "Hedera USDC payment created", detail)
+    result.record(4, "Create Hedera payment", passed, detail or f"transaction_id={payment_tx_id}", time.time() - t0)
+
+    # Step 2d: Verify the payment receipt on the mirror node
+    step(5, "Verify Hedera payment receipt on mirror node")
+    t0 = time.time()
+    if payment_tx_id:
+        ok, data, detail = api_get(
+            f"/v1/public/{PROJECT_ID}/hedera/payments/{payment_tx_id}/verify"
+        )
+    else:
+        ok, data, detail = False, None, "No transaction_id from payment step"
+    passed = checkpoint(ok, "Payment receipt verifiable", detail)
+    result.record(5, "Verify payment receipt", passed, detail, time.time() - t0)
+
+    # Step 6: x402 discovery sanity check (retained for Tutorial 02 curriculum)
+    step(6, "Check x402 discovery for Hedera metadata")
     t0 = time.time()
     ok, data, detail = api_get("/.well-known/x402")
     has_hedera = False
@@ -518,10 +606,10 @@ def run_tutorial_02(result: TestResult, persona: str) -> None:
         "x402 discovery includes Hedera metadata",
         detail or f"hedera_present={has_hedera}",
     )
-    result.record(3, "x402 Hedera discovery", passed, detail, time.time() - t0)
+    result.record(6, "x402 Hedera discovery", passed, detail, time.time() - t0)
 
-    # Step 4: Submit reputation feedback
-    step(4, "Submit reputation feedback")
+    # Step 7: Submit reputation feedback (matches Tutorial 02 §7-11)
+    step(7, "Submit reputation feedback")
     if persona == "vibe-coder":
         prompt_as_vibe_coder(
             "Submit reputation feedback for agent did:hedera:testnet:0.0.12345 "
@@ -541,28 +629,28 @@ def run_tutorial_02(result: TestResult, persona: str) -> None:
         expected_status=201,
     )
     passed = checkpoint(ok, "Feedback submitted", detail)
-    result.record(4, "Submit feedback", passed, detail, time.time() - t0)
+    result.record(7, "Submit feedback", passed, detail, time.time() - t0)
 
-    # Step 5: Get reputation score
-    step(5, "Get reputation score")
+    # Step 8: Get reputation score
+    step(8, "Get reputation score")
     t0 = time.time()
     ok, data, detail = api_get(f"/api/v1/hedera/reputation/{test_did}")
     passed = checkpoint(ok, "Reputation score calculated", detail)
-    result.record(5, "Get reputation", passed, detail, time.time() - t0)
+    result.record(8, "Get reputation", passed, detail, time.time() - t0)
 
-    # Step 6: Get feedback history
-    step(6, "Get feedback history")
+    # Step 9: Get feedback history
+    step(9, "Get feedback history")
     t0 = time.time()
     ok, data, detail = api_get(f"/api/v1/hedera/reputation/{test_did}/feedback")
     passed = checkpoint(ok, "Feedback history retrievable", detail)
-    result.record(6, "Feedback history", passed, detail, time.time() - t0)
+    result.record(9, "Feedback history", passed, detail, time.time() - t0)
 
-    # Step 7: Ranked agents
-    step(7, "List ranked agents")
+    # Step 10: Ranked agents
+    step(10, "List ranked agents")
     t0 = time.time()
     ok, data, detail = api_get("/api/v1/hedera/reputation/ranked")
     passed = checkpoint(ok, "Ranked agents listable", detail)
-    result.record(7, "Ranked agents", passed, detail, time.time() - t0)
+    result.record(10, "Ranked agents", passed, detail, time.time() - t0)
 
 
 # ---------------------------------------------------------------------------
@@ -684,16 +772,31 @@ def main() -> int:
         help="Tutorial to run (default: all)",
     )
     parser.add_argument(
+        "--project-id",
+        dest="project_id",
+        default=None,
+        help=(
+            "Project ID to run tutorials against. Overrides WORKSHOP_PROJECT_ID. "
+            f"Default: {DEFAULT_PROJECT_ID}"
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print what would happen, don't actually hit the server",
     )
     args = parser.parse_args()
 
+    # Precedence: --project-id > WORKSHOP_PROJECT_ID env > DEFAULT_PROJECT_ID
+    if args.project_id:
+        global PROJECT_ID
+        PROJECT_ID = args.project_id
+
     banner(f"Agent-402 Workshop E2E Test")
-    print(f"Persona:  {C.BOLD}{args.persona}{C.RESET}")
-    print(f"Tutorial: {C.BOLD}{args.tutorial}{C.RESET}")
-    print(f"Base URL: {BASE_URL}")
+    print(f"Persona:    {C.BOLD}{args.persona}{C.RESET}")
+    print(f"Tutorial:   {C.BOLD}{args.tutorial}{C.RESET}")
+    print(f"Base URL:   {BASE_URL}")
+    print(f"Project ID: {C.BOLD}{PROJECT_ID}{C.RESET}")
 
     if args.dry_run:
         say("Dry run mode — not actually testing")

--- a/scripts/workshop_smoke_test.py
+++ b/scripts/workshop_smoke_test.py
@@ -67,6 +67,34 @@ def check_dir_exists(path: str) -> bool:
     return True
 
 
+def check_orchestrator_project_id_exists() -> bool:
+    """
+    Assert the project ID the E2E orchestrator points at actually exists in
+    the deterministic project store. Prevents regression of issue #330, where
+    the orchestrator pointed at a non-existent project and every project-
+    scoped endpoint 404'd.
+    """
+    # Source-of-truth store
+    from app.services.project_store import project_store
+
+    # Mirror the orchestrator's resolution precedence:
+    # WORKSHOP_PROJECT_ID env > hard-coded default.
+    # (The --project-id CLI flag only matters at runtime; env vars are what
+    # the smoke test can observe statically.)
+    default_project_id = "proj_demo_u1_001"
+    project_id = os.environ.get("WORKSHOP_PROJECT_ID", default_project_id)
+
+    project = project_store.get_by_id(project_id)
+    if project is None:
+        raise AssertionError(
+            f"Orchestrator project '{project_id}' not found in project_store. "
+            "Either add it to _initialize_demo_projects() in "
+            "backend/app/services/project_store.py, or set WORKSHOP_PROJECT_ID "
+            "to an existing project."
+        )
+    return True
+
+
 def main():
     print("=" * 60)
     print("  Agent-402 Workshop Smoke Test")
@@ -159,6 +187,11 @@ def main():
     # Section 6: FastAPI app loads
     print("[6/6] Checking FastAPI app loads...")
     results.append(check("FastAPI app imports", lambda: check_import("app.main")))
+    # Regression guard for issue #330: the E2E orchestrator's project must exist.
+    results.append(check(
+        "Orchestrator project ID exists in project_store",
+        check_orchestrator_project_id_exists,
+    ))
     print()
 
     # Summary

--- a/tests/test_workshop_e2e_orchestrator.py
+++ b/tests/test_workshop_e2e_orchestrator.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for the workshop E2E test orchestrator.
+
+Covers the two fixes from #329 and #330:
+1. ensure_project_exists() verifies the configured project via
+   GET /v1/public/projects (it never tries to POST a new project, since
+   Agent-402 exposes no runtime project-creation endpoint).
+2. The orchestrator resolves PROJECT_ID with precedence
+   --project-id > WORKSHOP_PROJECT_ID env > DEFAULT_PROJECT_ID.
+3. The default is a project that actually exists in the deterministic
+   project_store (regression guard for #330).
+4. Tutorial 02 calls the Hedera wallet endpoints (not Circle) and does
+   not pass the invalid wallet_type "EOA" (regression guard for #329).
+
+These tests were written RED-first:
+- #330 tests fail on the pre-fix default "proj_test_change_in_production"
+  because it is not in project_store and ensure_project_exists() was
+  attempting a POST to a nonexistent create endpoint.
+- #329 tests fail on the pre-fix run_tutorial_02 source because it
+  contained hits against `/circle/wallets` with `wallet_type: "EOA"`.
+
+Built by AINative Dev Team
+Refs #329 #330
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ORCHESTRATOR_PATH = PROJECT_ROOT / "scripts" / "workshop_e2e_test.py"
+
+
+def _load_orchestrator():
+    """Import scripts/workshop_e2e_test.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "workshop_e2e_test", ORCHESTRATOR_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["workshop_e2e_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def orchestrator():
+    """Fresh import of the orchestrator module per test."""
+    # Ensure we get a fresh module so monkey-patching PROJECT_ID doesn't leak.
+    sys.modules.pop("workshop_e2e_test", None)
+    return _load_orchestrator()
+
+
+class DescribeDefaultProjectId:
+    """
+    Regression guard for #330: the default project ID must exist in the
+    deterministic project_store. Any future rename in project_store.py
+    without updating the orchestrator will fail this test.
+    """
+
+    def it_points_at_an_existing_deterministic_project(self, orchestrator):
+        # Late import so backend path setup above applies.
+        sys.path.insert(
+            0, str(PROJECT_ROOT / "backend")
+        )
+        from app.services.project_store import project_store
+
+        assert project_store.get_by_id(orchestrator.DEFAULT_PROJECT_ID) is not None, (
+            f"DEFAULT_PROJECT_ID '{orchestrator.DEFAULT_PROJECT_ID}' is not in "
+            "project_store. Pre-fix this pointed at "
+            "'proj_test_change_in_production', which did not exist and caused "
+            "every project-scoped endpoint to 404."
+        )
+
+    def it_is_not_the_broken_pre_fix_default(self, orchestrator):
+        assert orchestrator.DEFAULT_PROJECT_ID != "proj_test_change_in_production"
+
+
+class DescribeEnsureProjectExists:
+    """Tests for ensure_project_exists(): list-and-verify, never create."""
+
+    def it_returns_true_when_project_is_in_list(self, orchestrator):
+        def fake_api_get(path, expected_status=200):
+            assert path == "/v1/public/projects"
+            return (
+                True,
+                {
+                    "projects": [
+                        {"id": "proj_demo_u1_001", "name": "x"},
+                        {"id": "proj_demo_u1_002", "name": "y"},
+                    ],
+                    "total": 2,
+                },
+                "",
+            )
+
+        with patch.object(orchestrator, "api_get", side_effect=fake_api_get):
+            orchestrator.PROJECT_ID = "proj_demo_u1_001"
+            ok, detail = orchestrator.ensure_project_exists()
+        assert ok is True
+        assert detail == ""
+
+    def it_returns_false_with_helpful_detail_when_project_missing(
+        self, orchestrator
+    ):
+        def fake_api_get(path, expected_status=200):
+            return (
+                True,
+                {"projects": [{"id": "proj_demo_u1_001"}], "total": 1},
+                "",
+            )
+
+        with patch.object(orchestrator, "api_get", side_effect=fake_api_get):
+            orchestrator.PROJECT_ID = "proj_does_not_exist"
+            ok, detail = orchestrator.ensure_project_exists()
+
+        assert ok is False
+        assert "proj_does_not_exist" in detail
+        assert "Visible projects" in detail
+        assert "--project-id" in detail or "WORKSHOP_PROJECT_ID" in detail
+
+    def it_returns_false_when_list_endpoint_fails(self, orchestrator):
+        with patch.object(
+            orchestrator,
+            "api_get",
+            return_value=(False, None, "HTTP 500: oh no"),
+        ):
+            ok, detail = orchestrator.ensure_project_exists()
+        assert ok is False
+        assert "Could not list projects" in detail
+
+    def it_does_not_attempt_to_create_projects(self, orchestrator):
+        """Pre-fix ensure_project_exists() POSTed to /v1/public/projects,
+        which does not exist in Agent-402. Guard against that regression."""
+        call_log = []
+
+        def fake_api_get(path, expected_status=200):
+            call_log.append(("GET", path))
+            return True, {"projects": [], "total": 0}, ""
+
+        def fake_api_post(path, body, expected_status=201):
+            call_log.append(("POST", path))
+            return True, {}, ""
+
+        with patch.object(orchestrator, "api_get", side_effect=fake_api_get), \
+             patch.object(orchestrator, "api_post", side_effect=fake_api_post):
+            orchestrator.ensure_project_exists()
+
+        assert ("POST", "/v1/public/projects") not in call_log
+        assert all(verb == "GET" for verb, _ in call_log)
+
+
+class DescribeProjectIdCliAndEnv:
+    """
+    Resolution precedence: --project-id > WORKSHOP_PROJECT_ID env > default.
+    These tests verify the module picks up the env var at import time and
+    that main() overrides it when the CLI flag is supplied.
+    """
+
+    def it_uses_env_override_at_module_load(self):
+        sys.modules.pop("workshop_e2e_test", None)
+        with patch.dict(os.environ, {"WORKSHOP_PROJECT_ID": "proj_demo_u1_002"}):
+            mod = _load_orchestrator()
+        assert mod.PROJECT_ID == "proj_demo_u1_002"
+        assert mod.DEFAULT_PROJECT_ID == "proj_demo_u1_001"
+
+    def it_falls_back_to_default_when_env_unset(self):
+        sys.modules.pop("workshop_e2e_test", None)
+        env = {k: v for k, v in os.environ.items() if k != "WORKSHOP_PROJECT_ID"}
+        with patch.dict(os.environ, env, clear=True):
+            mod = _load_orchestrator()
+        assert mod.PROJECT_ID == mod.DEFAULT_PROJECT_ID == "proj_demo_u1_001"
+
+    def it_exposes_project_id_cli_flag(self, orchestrator):
+        source = ORCHESTRATOR_PATH.read_text()
+        # Minimal structural check — the flag must be wired into argparse.
+        assert '"--project-id"' in source
+        assert "WORKSHOP_PROJECT_ID" in source
+
+
+class DescribeTutorial02UsesHedera:
+    """
+    Regression guard for #329: Tutorial 02 content teaches Hedera wallets,
+    so the orchestrator must test Hedera wallets (not Circle), and must
+    never use the invalid wallet_type "EOA".
+    """
+
+    def it_hits_hedera_wallet_endpoint_in_tutorial_02(self):
+        source = ORCHESTRATOR_PATH.read_text()
+        # Find the run_tutorial_02 body.
+        start = source.index("def run_tutorial_02")
+        end = source.index("def run_tutorial_03")
+        t02 = source[start:end]
+
+        assert "/hedera/wallets" in t02, (
+            "run_tutorial_02 must POST to /v1/public/{project_id}/hedera/wallets; "
+            "Tutorial 02 teaches Hedera wallets."
+        )
+        assert "associate-usdc" in t02
+        assert "/hedera/payments" in t02
+        assert "/verify" in t02
+
+    def it_does_not_use_invalid_circle_eoa_wallet_type(self):
+        source = ORCHESTRATOR_PATH.read_text()
+        start = source.index("def run_tutorial_02")
+        end = source.index("def run_tutorial_03")
+        t02 = source[start:end]
+
+        assert '"EOA"' not in t02 and "'EOA'" not in t02, (
+            "Tutorial 02 must not submit wallet_type=EOA; the Circle schema "
+            "(backend/app/schemas/circle.py) enumerates analyst|compliance|"
+            "transaction and will return HTTP 422."
+        )
+
+    def it_does_not_call_circle_wallets_in_tutorial_02(self):
+        source = ORCHESTRATOR_PATH.read_text()
+        start = source.index("def run_tutorial_02")
+        end = source.index("def run_tutorial_03")
+        t02 = source[start:end]
+
+        assert "/circle/wallets" not in t02, (
+            "Circle wallet coverage must not live in Tutorial 02 — Tutorial 02 "
+            "teaches Hedera. Circle coverage belongs in a future Tutorial 04."
+        )
+
+
+class DescribeSmokeTestRegressionGuard:
+    """
+    The smoke test must fail fast when the orchestrator's project ID is
+    missing from project_store. This is the belt-and-braces check for #330.
+    """
+
+    def it_asserts_project_id_exists_in_store(self):
+        backend_path = PROJECT_ROOT / "backend"
+        sys.path.insert(0, str(backend_path))
+        spec = importlib.util.spec_from_file_location(
+            "workshop_smoke_test",
+            str(PROJECT_ROOT / "scripts" / "workshop_smoke_test.py"),
+        )
+        assert spec is not None and spec.loader is not None
+        smoke = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(smoke)
+
+        assert smoke.check_orchestrator_project_id_exists() is True
+
+    def it_raises_for_unknown_project_id(self):
+        backend_path = PROJECT_ROOT / "backend"
+        sys.path.insert(0, str(backend_path))
+        spec = importlib.util.spec_from_file_location(
+            "workshop_smoke_test",
+            str(PROJECT_ROOT / "scripts" / "workshop_smoke_test.py"),
+        )
+        assert spec is not None and spec.loader is not None
+        smoke = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(smoke)
+
+        with patch.dict(
+            os.environ, {"WORKSHOP_PROJECT_ID": "proj_does_not_exist"}
+        ):
+            with pytest.raises(AssertionError) as exc:
+                smoke.check_orchestrator_project_id_exists()
+        assert "proj_does_not_exist" in str(exc.value)


### PR DESCRIPTION
## Summary

- **Closes #330** — orchestrator now uses an existing deterministic project (`proj_demo_u1_001`) instead of the nonexistent `proj_test_change_in_production`. Added `--project-id` CLI flag and `WORKSHOP_PROJECT_ID` env override.
- **Closes #329** — Tutorial 02 Steps 1–5 rewritten to test Hedera wallets (matching Tutorial 02 curriculum) instead of Circle wallets with an invalid `wallet_type: "EOA"`. Reputation steps preserved and renumbered (Steps 7–10).
- Smoke-test regression guard added: `scripts/workshop_smoke_test.py` now imports `project_store` and fails loudly if the orchestrator's project ID doesn't resolve.

## Bug #330 detail

Agent-402 exposes no runtime project-creation endpoint, and workshop-mode middleware does not auto-provision. The previous default ID simply didn't exist in `backend/app/services/project_store.py`, so every project-scoped endpoint 404'd with `PROJECT_NOT_FOUND` and Tutorial 01 Step 1 (agent creation) cascade-failed the whole run.

Fix: switch default to `proj_demo_u1_001` (owned by `user_1`, the `demo_key_user1_abc123` API key), and verify reachability at startup via `GET /v1/public/projects`. Resolution precedence is `--project-id` > `WORKSHOP_PROJECT_ID` > default.

## Bug #329 detail

Tutorial 02 teaches Hedera wallets, but the orchestrator tested Circle wallets using `wallet_type: "EOA"` — invalid because `backend/app/schemas/circle.py:63` enumerates `analyst|compliance|transaction`. Two bugs in one (wrong product + wrong enum).

Replaced Tutorial 02 Steps 1–2 with the full Hedera flow:
- Step 1 — `POST /v1/public/{project_id}/hedera/wallets` (create)
- Step 2 — `POST /v1/public/{project_id}/hedera/wallets/{account_id}/associate-usdc`
- Step 3 — `GET  /v1/public/{project_id}/hedera/wallets/{account_id}/balance`
- Step 4 — `POST /v1/public/{project_id}/hedera/payments` (USDC transfer)
- Step 5 — `GET  /v1/public/{project_id}/hedera/payments/{transaction_id}/verify`

Circle coverage is **not deleted** — Agent-402 supports both wallet products. It belongs in a future Tutorial 04 and can be added as a separate task.

## Before/after E2E numbers

`python3 scripts/workshop_e2e_test.py --persona developer --tutorial all`

| | Before | After |
|---|---|---|
| Tutorial 01 | 1/2 | 1/2 |
| Tutorial 02 | 4/7 | 4/10 |
| Tutorial 03 | 3/7 | 3/7 |
| **Total**   | **8/16** | **8/19** |

Checkpoint count grew because Tutorial 02 now exercises the Hedera wallet + payment flow the tutorial actually teaches. Both targeted bugs (404 project-not-found, 422 wallet_type validation) are gone. The remaining failures trace to in-flight bugs outside this PR's scope: #322 (`HederaClient` missing `submit_hcs_message`) and #328 (ZeroDB mock 404s). Once those land, Tutorial 02 alone should climb to 10/10.

## Test plan
- [x] `python3 scripts/workshop_smoke_test.py` — 50/50 passing (includes new regression guard)
- [x] `python3 scripts/workshop_e2e_test.py --persona developer --tutorial all` — 8/19 (baseline 8/16)
- [ ] Spot-check `python3 scripts/workshop_e2e_test.py --project-id proj_demo_u1_002` to confirm override plumbing
- [ ] Re-run full E2E after #322 and #328 land to confirm Tutorial 02 reaches 10/10

Built by AINative Dev Team