### PR TITLE
fix(zerodb-client): short-circuit query_rows in mock mode (#328)

### DIFF
--- a/backend/app/services/zerodb_client.py
+++ b/backend/app/services/zerodb_client.py
@@ -306,6 +306,13 @@ class ZeroDBClient:
 
         POST /v1/public/zerodb/{project_id}/database/tables/{table_name}/query
         """
+        # Issue #328: In mock mode, no ZeroDB project exists to query against,
+        # so short-circuit with an empty result set before making any HTTP call.
+        # This keeps read-path endpoints (e.g. /marketplace/browse, /search)
+        # returning 200 locally instead of bubbling the upstream 404 as a 500.
+        if self._mock_mode:
+            return {"rows": [], "total": 0}
+
         payload = {
             "filter": filter,
             "limit": limit,

--- a/backend/app/tests/api/test_marketplace_mock_mode.py
+++ b/backend/app/tests/api/test_marketplace_mock_mode.py
@@ -1,0 +1,104 @@
+"""
+API-level tests for /marketplace/browse and /marketplace/search in mock mode.
+
+Issue #328: Before the fix, both endpoints returned HTTP 500 because the
+production ZeroDBClient (in mock mode) fell through to real HTTP calls
+against api.ainative.studio and raised HTTPStatusError on the 404 that
+comes back for absent `mock_project` tables. With the fix, mock mode
+short-circuits `query_rows` to an empty result and both endpoints return
+200 with an empty items list.
+
+Built by AINative Dev Team
+Refs #328
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.marketplace import router as marketplace_router
+from app.services.marketplace_service import MarketplaceService
+from app.services import marketplace_service as marketplace_service_module
+from app.services.zerodb_client import ZeroDBClient
+
+
+@pytest.fixture
+def mock_mode_marketplace_client(monkeypatch):
+    """
+    Build a TestClient against the marketplace router, backed by a real
+    (not MockZeroDBClient) ZeroDBClient running in mock mode. This is the
+    exact configuration that the workshop's local/demo deployment uses.
+    """
+    # Force the production client into mock mode (no creds).
+    monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+    monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+
+    real_client_in_mock_mode = ZeroDBClient(api_key=None, project_id=None)
+    assert real_client_in_mock_mode._mock_mode is True
+
+    # Replace the singleton the marketplace router resolves against.
+    monkeypatch.setattr(
+        marketplace_service_module,
+        "marketplace_service",
+        MarketplaceService(client=real_client_in_mock_mode),
+    )
+
+    app = FastAPI()
+    app.include_router(marketplace_router)
+    return TestClient(app)
+
+
+class DescribeMarketplaceBrowseInMockMode:
+    """GET /marketplace/browse must return 200 in mock mode — Issue #328."""
+
+    def it_returns_200_with_empty_items(self, mock_mode_marketplace_client):
+        response = mock_mode_marketplace_client.get("/marketplace/browse")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+        assert body["limit"] == 20
+        assert body["offset"] == 0
+
+    def it_respects_pagination_params(self, mock_mode_marketplace_client):
+        response = mock_mode_marketplace_client.get(
+            "/marketplace/browse",
+            params={"limit": 5, "offset": 10, "sort_by": "highest_rated"},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items"] == []
+        assert body["limit"] == 5
+        assert body["offset"] == 10
+
+
+class DescribeMarketplaceSearchInMockMode:
+    """POST /marketplace/search must return 200 in mock mode — Issue #328."""
+
+    def it_returns_200_with_empty_items(self, mock_mode_marketplace_client):
+        response = mock_mode_marketplace_client.post(
+            "/marketplace/search",
+            json={"query": "finance"},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def it_accepts_filters_without_erroring(self, mock_mode_marketplace_client):
+        response = mock_mode_marketplace_client.post(
+            "/marketplace/search",
+            json={
+                "query": "analytics",
+                "min_reputation": 0.5,
+                "price_range": {"min": 0.0, "max": 1.0},
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items"] == []

--- a/backend/app/tests/test_zerodb_client.py
+++ b/backend/app/tests/test_zerodb_client.py
@@ -1,0 +1,72 @@
+"""
+Tests for the real ZeroDBClient (not the MockZeroDBClient fixture).
+
+Issue #328: In mock mode (no ZERODB_API_KEY / ZERODB_PROJECT_ID set) the
+production client must NOT make HTTP calls. Previously query_rows fell
+through to the real API at api.ainative.studio, got a 404 on the absent
+mock_project tables, and bubbled up as 500s on /marketplace/browse and
+/marketplace/search.
+
+Built by AINative Dev Team
+Refs #328
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.zerodb_client import ZeroDBClient
+
+
+def _fresh_mock_client() -> ZeroDBClient:
+    """Construct a ZeroDBClient with no credentials (forces mock mode)."""
+    return ZeroDBClient(api_key=None, project_id=None)
+
+
+class DescribeZeroDBClientMockMode:
+    """ZeroDBClient must short-circuit HTTP calls when no credentials are set."""
+
+    def it_enters_mock_mode_without_credentials(self, monkeypatch):
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+
+        client = ZeroDBClient()
+        assert client._mock_mode is True
+
+    @pytest.mark.asyncio
+    async def it_query_rows_returns_empty_result_without_http(self, monkeypatch):
+        """
+        Issue #328 regression — query_rows must return {"rows": [], "total": 0}
+        in mock mode instead of calling the real ZeroDB API.
+        """
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+
+        # Fail hard if httpx is used — mock mode must not make network calls.
+        import httpx
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("mock mode must not open an httpx.AsyncClient")
+
+        monkeypatch.setattr(httpx, "AsyncClient", _boom)
+
+        client = _fresh_mock_client()
+        result = await client.query_rows(
+            "marketplace_listings",
+            filter={"active": True},
+            limit=20,
+        )
+
+        assert result == {"rows": [], "total": 0}
+
+    @pytest.mark.asyncio
+    async def it_query_rows_empty_result_for_any_table(self, monkeypatch):
+        """Short-circuit applies uniformly regardless of table name."""
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+
+        client = _fresh_mock_client()
+
+        for table in ("marketplace_listings", "agent_installations", "anything_else"):
+            result = await client.query_rows(table, filter={})
+            assert result["rows"] == []
+            assert result["total"] == 0


### PR DESCRIPTION
## Summary

- Short-circuits `ZeroDBClient.query_rows` to `{"rows": [], "total": 0}` when the client is in mock mode (no `ZERODB_API_KEY` / `ZERODB_PROJECT_ID`), before any HTTP call
- Fixes P0 where `GET /marketplace/browse` and `POST /marketplace/search` returned HTTP 500 in the workshop's local/demo mode because the real ZeroDB API returned 404 on absent `mock_project` tables and `httpx.HTTPStatusError` bubbled up as 500
- Restores Tutorial 03 Steps 5 (browse) and 6 (search) in the workshop E2E

## Root cause

At startup `ZeroDBClient` logs "running in mock mode - credentials not provided" but `query_rows` still called the real API at `https://api.ainative.studio/v1/public/zerodb/mock_project/database/tables/marketplace_listings/query`, which 404'd because that table doesn't exist for the placeholder project.

## Fix

Check `self._mock_mode` at the top of `query_rows` and return an empty result set before any HTTP call. Matches the shape callers (`marketplace_service.browse_agents`, `search_agents`, `get_published_agent`, etc.) already expect from the API response.

## Tests (TDD red/green)

- [backend/app/tests/test_zerodb_client.py](backend/app/tests/test_zerodb_client.py) — unit-level: asserts mock mode never opens an `httpx.AsyncClient` and `query_rows` returns `{"rows": [], "total": 0}` for any table
- [backend/app/tests/api/test_marketplace_mock_mode.py](backend/app/tests/api/test_marketplace_mock_mode.py) — API-level: drives the full marketplace router against a real `ZeroDBClient` forced into mock mode; asserts `GET /marketplace/browse` and `POST /marketplace/search` return 200 with empty items

Red phase: the second unit test reproduced the exact reported error —
```
httpx.HTTPStatusError: Client error '404 ' for url
'https://api.ainative.studio/v1/public/zerodb/mock_project/database/tables/marketplace_listings/query'
```
Green phase: 7/7 new tests pass; full suite delta is −6 failed / +13 passed / 0 regressions (6 pre-existing tests were hitting the same mock-mode fall-through).

## Workshop E2E result

`python3 scripts/workshop_e2e_test.py --persona developer --tutorial all`

**Tutorial 03** — 5/7 checkpoints passing (was 3/7):
- Step 5 Marketplace browse: **FAIL → PASS**
- Step 6 Marketplace search: **FAIL → PASS**
- Step 7 Marketplace categories: PASS (already passing, no ZeroDB dep)

**Total**: 10/16 checkpoints passing. Remaining failures (Tutorial 01 Step 1, Tutorial 02 Steps 1/2/4, Tutorial 03 Steps 3/4) are unrelated to #328 and pre-date this change.

## Test plan

- [x] Red: new tests fail with the exact 404 from the issue
- [x] Green: new tests pass after the one-block fix in `query_rows`
- [x] Full backend suite: no regressions (same 81 errors, same 500 failures that pre-date this change; +7 new passes from new tests, +6 fixed pre-existing)
- [x] Workshop E2E: Tutorial 03 Steps 5 & 6 flip FAIL → PASS
- [x] `GET /marketplace/categories` still 200 (no regression on hardcoded route)

Built by AINative Dev Team
Closes #328