### PR TITLE
fix(zerodb): route mock-mode CRUD to in-memory store (closes #345 #328)

### DIFF
--- a/backend/app/services/zerodb_client.py
+++ b/backend/app/services/zerodb_client.py
@@ -11,14 +11,200 @@ Endpoints implemented:
 - Rows: CRUD with query support
 - Vectors: Upsert, search, list
 - Embeddings: Generate, embed-and-store, semantic search
+
+Mock mode: when no credentials are provided, CRUD operations are served
+from an in-memory store instead of issuing HTTP requests. This keeps
+workshop/local setups functional without ZeroDB credentials (closes #345).
 """
 import os
 import logging
+import uuid
 from typing import Dict, Any, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+class _InMemoryStore:
+    """Minimal in-memory backing for `ZeroDBClient` mock mode.
+
+    Supports direct-equality filters and the `$eq`, `$gt`, `$gte`, `$lt`,
+    `$lte` operators — enough for the workshop tutorials and current
+    service-layer callers. Rows are keyed by a generated string `id`.
+    """
+
+    def __init__(self) -> None:
+        self.tables: Dict[str, Dict[str, Any]] = {}
+        self.rows: Dict[str, List[Dict[str, Any]]] = {}
+        self.vectors: List[Dict[str, Any]] = []
+
+    def _table(self, name: str) -> List[Dict[str, Any]]:
+        return self.rows.setdefault(name, [])
+
+    @staticmethod
+    def _matches(row: Dict[str, Any], query: Dict[str, Any]) -> bool:
+        for field, condition in query.items():
+            value = row.get(field)
+            if isinstance(condition, dict):
+                for op, operand in condition.items():
+                    if op == "$eq" and value != operand:
+                        return False
+                    if op == "$gte" and (value is None or value < operand):
+                        return False
+                    if op == "$lte" and (value is None or value > operand):
+                        return False
+                    if op == "$gt" and (value is None or value <= operand):
+                        return False
+                    if op == "$lt" and (value is None or value >= operand):
+                        return False
+            else:
+                if value != condition:
+                    return False
+        return True
+
+    def insert_row(self, table: str, row_data: Dict[str, Any]) -> Dict[str, Any]:
+        rows = self._table(table)
+        row_id = str(uuid.uuid4())
+        row = {"id": row_id, "row_id": row_id, **row_data}
+        rows.append(row)
+        return {"success": True, "row_id": row_id, "row_data": row}
+
+    def query_rows(
+        self,
+        table: str,
+        filter_query: Optional[Dict[str, Any]],
+        limit: int,
+        skip: int,
+    ) -> Dict[str, Any]:
+        rows = self.rows.get(table, [])
+        filtered = (
+            [r for r in rows if self._matches(r, filter_query)]
+            if filter_query
+            else list(rows)
+        )
+        total = len(filtered)
+        page = filtered[skip : skip + limit]
+        return {"rows": page, "total": total}
+
+    def list_rows(self, table: str, skip: int, limit: int) -> Dict[str, Any]:
+        return self.query_rows(table, None, limit=limit, skip=skip)
+
+    def _find_row(
+        self, table: str, row_id: str
+    ) -> Optional[Dict[str, Any]]:
+        for row in self.rows.get(table, []):
+            if str(row.get("id")) == str(row_id) or str(row.get("row_id")) == str(row_id):
+                return row
+        return None
+
+    def get_row(self, table: str, row_id: str) -> Dict[str, Any]:
+        row = self._find_row(table, row_id)
+        if row is None:
+            raise KeyError(f"Row {row_id} not found in table {table}")
+        return {"row_id": row.get("id"), "row_data": row}
+
+    def update_row(
+        self, table: str, row_id: str, row_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        rows = self.rows.get(table)
+        if not rows:
+            raise KeyError(f"Table {table} not found")
+        for i, row in enumerate(rows):
+            if str(row.get("id")) == str(row_id) or str(row.get("row_id")) == str(row_id):
+                stored_id = row.get("id")
+                updated = {**row_data, "id": stored_id, "row_id": stored_id}
+                rows[i] = updated
+                return {"success": True, "row_id": stored_id, "row_data": updated}
+        raise KeyError(f"Row {row_id} not found in table {table}")
+
+    def delete_row(self, table: str, row_id: str) -> Dict[str, Any]:
+        rows = self.rows.get(table)
+        if not rows:
+            raise KeyError(f"Table {table} not found")
+        for i, row in enumerate(rows):
+            if str(row.get("id")) == str(row_id) or str(row.get("row_id")) == str(row_id):
+                stored_id = row.get("id")
+                rows.pop(i)
+                return {"success": True, "row_id": stored_id}
+        raise KeyError(f"Row {row_id} not found in table {table}")
+
+    def create_table(
+        self, table_name: str, schema_definition: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        meta = {
+            "id": f"tbl_{uuid.uuid4().hex[:12]}",
+            "table_name": table_name,
+            "schema": schema_definition,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self.tables[table_name] = meta
+        self.rows.setdefault(table_name, [])
+        return meta
+
+    def list_tables(self) -> Dict[str, Any]:
+        return {"tables": list(self.tables.values()), "total": len(self.tables)}
+
+    def get_table(self, table_id: str) -> Dict[str, Any]:
+        for meta in self.tables.values():
+            if meta.get("id") == table_id or meta.get("table_name") == table_id:
+                return meta
+        raise KeyError(f"Table {table_id} not found")
+
+    def delete_table(self, table_name: str) -> Dict[str, Any]:
+        self.tables.pop(table_name, None)
+        self.rows.pop(table_name, None)
+        return {"success": True, "table_name": table_name}
+
+    def upsert_vector(
+        self,
+        vector_embedding: List[float],
+        document: str,
+        namespace: str,
+        vector_id: Optional[str],
+        vector_metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        vid = vector_id or f"vec_{uuid.uuid4().hex[:16]}"
+        record = {
+            "vector_id": vid,
+            "vector_embedding": vector_embedding,
+            "document": document,
+            "namespace": namespace,
+            "metadata": vector_metadata or {},
+        }
+        for i, existing in enumerate(self.vectors):
+            if existing.get("vector_id") == vid:
+                self.vectors[i] = record
+                return {"success": True, "vector_id": vid, "updated": True}
+        self.vectors.append(record)
+        return {"success": True, "vector_id": vid, "updated": False}
+
+    def search_vectors(
+        self,
+        namespace: Optional[str],
+        limit: int,
+    ) -> Dict[str, Any]:
+        pool = [
+            v for v in self.vectors
+            if namespace is None or v.get("namespace") == namespace
+        ]
+        matches = [
+            {
+                "vector_id": v["vector_id"],
+                "document": v["document"],
+                "metadata": v.get("metadata", {}),
+                "score": 0.9,
+            }
+            for v in pool[:limit]
+        ]
+        return {"matches": matches, "count": len(matches)}
+
+    def list_vectors(self, limit: int, offset: int) -> Dict[str, Any]:
+        page = self.vectors[offset : offset + limit]
+        return {"vectors": page, "total": len(self.vectors)}
+
+    def vector_stats(self) -> Dict[str, Any]:
+        return {"total_vectors": len(self.vectors)}
 
 
 class ZeroDBClient:
@@ -52,10 +238,12 @@ class ZeroDBClient:
         # Allow client to work without credentials (will use mock storage)
         self._mock_mode = not (self.api_key and self.project_id)
 
+        self._store: Optional[_InMemoryStore] = None
         if self._mock_mode:
             logger.warning("ZeroDBClient running in mock mode - credentials not provided")
             self.api_key = "mock_key"
             self.project_id = "mock_project"
+            self._store = _InMemoryStore()
 
         self.headers = {
             "X-API-Key": self.api_key,
@@ -84,6 +272,15 @@ class ZeroDBClient:
         Returns:
             Database status including enabled features and usage stats
         """
+        if self._mock_mode:
+            return {
+                "database_enabled": True,
+                "project_id": self.project_id,
+                "mock": True,
+                "tables": len(self._store.tables),
+                "vectors": len(self._store.vectors),
+            }
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 self._db_base,
@@ -106,6 +303,9 @@ class ZeroDBClient:
         Returns:
             Paginated list of tables
         """
+        if self._mock_mode:
+            return self._store.list_tables()
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/tables",
@@ -137,6 +337,9 @@ class ZeroDBClient:
             "schema_definition": schema_definition
         }
 
+        if self._mock_mode:
+            return self._store.create_table(table_name, schema_definition)
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self._db_base}/tables",
@@ -153,6 +356,9 @@ class ZeroDBClient:
 
         GET /v1/public/zerodb/{project_id}/database/tables/{table_id}
         """
+        if self._mock_mode:
+            return self._store.get_table(table_id)
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/tables/{table_id}",
@@ -168,6 +374,9 @@ class ZeroDBClient:
 
         DELETE /v1/public/zerodb/{project_id}/database/tables/{table_name}
         """
+        if self._mock_mode:
+            return self._store.delete_table(table_name)
+
         async with httpx.AsyncClient() as client:
             response = await client.delete(
                 f"{self._db_base}/tables/{table_name}",
@@ -200,6 +409,9 @@ class ZeroDBClient:
         """
         payload = {"row_data": row_data}
 
+        if self._mock_mode:
+            return self._store.insert_row(table_name, row_data)
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self._db_base}/tables/{table_name}/rows",
@@ -223,6 +435,9 @@ class ZeroDBClient:
         """
         params = {"skip": skip, "limit": limit}
 
+        if self._mock_mode:
+            return self._store.list_rows(table_name, skip=skip, limit=limit)
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/tables/{table_name}/rows",
@@ -243,6 +458,9 @@ class ZeroDBClient:
 
         GET /v1/public/zerodb/{project_id}/database/tables/{table_name}/rows/{row_id}
         """
+        if self._mock_mode:
+            return self._store.get_row(table_name, row_id)
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/tables/{table_name}/rows/{row_id}",
@@ -265,6 +483,9 @@ class ZeroDBClient:
         """
         payload = {"row_data": row_data}
 
+        if self._mock_mode:
+            return self._store.update_row(table_name, row_id, row_data)
+
         async with httpx.AsyncClient() as client:
             response = await client.put(
                 f"{self._db_base}/tables/{table_name}/rows/{row_id}",
@@ -285,6 +506,9 @@ class ZeroDBClient:
 
         DELETE /v1/public/zerodb/{project_id}/database/tables/{table_name}/rows/{row_id}
         """
+        if self._mock_mode:
+            return self._store.delete_row(table_name, row_id)
+
         async with httpx.AsyncClient() as client:
             response = await client.delete(
                 f"{self._db_base}/tables/{table_name}/rows/{row_id}",
@@ -311,6 +535,11 @@ class ZeroDBClient:
             "limit": limit,
             "skip": skip
         }
+
+        if self._mock_mode:
+            return self._store.query_rows(
+                table_name, filter, limit=limit, skip=skip
+            )
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -349,6 +578,15 @@ class ZeroDBClient:
         if vector_metadata:
             payload["vector_metadata"] = vector_metadata
 
+        if self._mock_mode:
+            return self._store.upsert_vector(
+                vector_embedding=vector_embedding,
+                document=document,
+                namespace=namespace,
+                vector_id=vector_id,
+                vector_metadata=vector_metadata,
+            )
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self._db_base}/vectors/upsert",
@@ -382,6 +620,9 @@ class ZeroDBClient:
         if metadata_filter:
             payload["metadata_filter"] = metadata_filter
 
+        if self._mock_mode:
+            return self._store.search_vectors(namespace=namespace, limit=limit)
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self._db_base}/vectors/search",
@@ -404,6 +645,9 @@ class ZeroDBClient:
         """
         params = {"limit": limit, "offset": offset}
 
+        if self._mock_mode:
+            return self._store.list_vectors(limit=limit, offset=offset)
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/vectors",
@@ -420,6 +664,9 @@ class ZeroDBClient:
 
         GET /v1/public/zerodb/{project_id}/database/vectors/stats
         """
+        if self._mock_mode:
+            return self._store.vector_stats()
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._db_base}/vectors/stats",
@@ -439,6 +686,9 @@ class ZeroDBClient:
 
         GET /v1/public/zerodb/{project_id}/embeddings/models
         """
+        if self._mock_mode:
+            return [{"model": "BAAI/bge-small-en-v1.5", "dimensions": 384, "mock": True}]
+
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{self._embed_base}/models",
@@ -464,6 +714,18 @@ class ZeroDBClient:
             "texts": texts,
             "model": model
         }
+
+        if self._mock_mode:
+            try:
+                from app.core.config import SUPPORTED_MODELS, DEFAULT_EMBEDDING_DIMENSIONS
+                dims = SUPPORTED_MODELS.get(model, DEFAULT_EMBEDDING_DIMENSIONS)
+            except Exception:
+                dims = 384
+            return {
+                "embeddings": [[0.1] * dims for _ in texts],
+                "model": model,
+                "dimensions": dims,
+            }
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -497,6 +759,24 @@ class ZeroDBClient:
         if metadata:
             payload["metadata"] = metadata
 
+        if self._mock_mode:
+            vector_ids: List[str] = []
+            for i, text in enumerate(texts):
+                text_meta = metadata[i] if metadata and i < len(metadata) else {}
+                stored = self._store.upsert_vector(
+                    vector_embedding=[0.0] * 384,
+                    document=text,
+                    namespace=namespace,
+                    vector_id=None,
+                    vector_metadata=text_meta,
+                )
+                vector_ids.append(stored["vector_id"])
+            return {
+                "success": True,
+                "vector_ids": vector_ids,
+                "count": len(vector_ids),
+            }
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{self._embed_base}/embed-and-store",
@@ -525,6 +805,9 @@ class ZeroDBClient:
             "namespace": namespace,
             "model": model
         }
+
+        if self._mock_mode:
+            return self._store.search_vectors(namespace=namespace, limit=top_k)
 
         async with httpx.AsyncClient() as client:
             response = await client.post(

--- a/backend/app/tests/test_zerodb_client.py
+++ b/backend/app/tests/test_zerodb_client.py
@@ -1,0 +1,251 @@
+"""
+Tests for ZeroDBClient mock-mode behavior.
+
+Closes #345 (and subsumes #328): in mock mode the client must service
+CRUD operations from an in-memory store and NEVER issue HTTP requests.
+These tests run against the real `ZeroDBClient` class (not the
+`MockZeroDBClient` fixture) to verify that a credential-less production
+boot can still service requests without 404s.
+
+Refs #345 #328
+Built by AINative Dev Team
+"""
+import os
+from typing import Any, Dict
+
+import httpx
+import pytest
+
+from app.services.zerodb_client import ZeroDBClient
+
+
+@pytest.fixture
+def mock_client(monkeypatch: pytest.MonkeyPatch) -> ZeroDBClient:
+    """Instantiate ZeroDBClient with no credentials so it enters mock mode."""
+    monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+    monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+    client = ZeroDBClient(api_key=None, project_id=None)
+    assert client._mock_mode is True, "test precondition: client must be in mock mode"
+    return client
+
+
+@pytest.fixture
+def http_blocker(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
+    """Replace httpx.AsyncClient with a spy that fails loudly on any use."""
+    counter = {"calls": 0}
+
+    class _BlockingAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            counter["calls"] += 1
+
+        async def __aenter__(self) -> "_BlockingAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def _boom(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError(
+                "mock-mode client must not perform HTTP requests"
+            )
+
+        get = _boom
+        post = _boom
+        put = _boom
+        delete = _boom
+        patch = _boom
+        request = _boom
+
+    monkeypatch.setattr(httpx, "AsyncClient", _BlockingAsyncClient)
+    return counter
+
+
+class TestMockModeDetection:
+    def test_no_credentials_enters_mock_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+        client = ZeroDBClient(api_key=None, project_id=None)
+        assert client._mock_mode is True
+
+    def test_with_credentials_is_not_mock(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+        client = ZeroDBClient(api_key="real_key", project_id="proj_real")
+        assert client._mock_mode is False
+
+
+class TestInsertRowMockMode:
+    @pytest.mark.asyncio
+    async def test_insert_row_does_not_call_http(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        result = await mock_client.insert_row("agents", {"name": "A"})
+        assert http_blocker["calls"] == 0
+        assert result.get("success") is True
+        assert "row_id" in result
+
+    @pytest.mark.asyncio
+    async def test_insert_row_returns_inserted_data(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        result = await mock_client.insert_row(
+            "agents", {"project_id": "proj_1", "name": "Agent X"}
+        )
+        assert result["row_data"]["project_id"] == "proj_1"
+        assert result["row_data"]["name"] == "Agent X"
+
+    @pytest.mark.asyncio
+    async def test_insert_row_generates_unique_ids(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        a = await mock_client.insert_row("agents", {"name": "A"})
+        b = await mock_client.insert_row("agents", {"name": "B"})
+        assert a["row_id"] != b["row_id"]
+
+
+class TestQueryRowsMockMode:
+    @pytest.mark.asyncio
+    async def test_query_empty_table_returns_empty(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        result = await mock_client.query_rows("nothing_here", filter={})
+        assert http_blocker["calls"] == 0
+        assert result["rows"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_query_round_trips_inserted_rows(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        await mock_client.insert_row("agents", {"project_id": "p1", "name": "A"})
+        await mock_client.insert_row("agents", {"project_id": "p1", "name": "B"})
+        await mock_client.insert_row("agents", {"project_id": "p2", "name": "C"})
+
+        result = await mock_client.query_rows(
+            "agents", filter={"project_id": {"$eq": "p1"}}
+        )
+        assert result["total"] == 2
+        assert all(r["project_id"] == "p1" for r in result["rows"])
+
+    @pytest.mark.asyncio
+    async def test_marketplace_listings_query_returns_empty_not_404(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        """Regression for #328: marketplace browse must not 500 in mock mode."""
+        result = await mock_client.query_rows("marketplace_listings", filter={})
+        assert result["rows"] == []
+        assert result["total"] == 0
+
+
+class TestGetRowMockMode:
+    @pytest.mark.asyncio
+    async def test_get_row_returns_inserted_row(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        inserted = await mock_client.insert_row("agents", {"name": "A"})
+        row_id = inserted["row_id"]
+
+        fetched = await mock_client.get_row("agents", str(row_id))
+        assert fetched["row_data"]["name"] == "A"
+        assert http_blocker["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_row_missing_raises(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        with pytest.raises(Exception):
+            await mock_client.get_row("agents", "nonexistent-id")
+
+
+class TestUpdateRowMockMode:
+    @pytest.mark.asyncio
+    async def test_update_row_persists_changes(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        inserted = await mock_client.insert_row("agents", {"name": "Old"})
+        row_id = str(inserted["row_id"])
+
+        updated = await mock_client.update_row(
+            "agents", row_id, {"name": "New", "status": "active"}
+        )
+        assert updated["row_data"]["name"] == "New"
+
+        fetched = await mock_client.get_row("agents", row_id)
+        assert fetched["row_data"]["name"] == "New"
+        assert http_blocker["calls"] == 0
+
+
+class TestDeleteRowMockMode:
+    @pytest.mark.asyncio
+    async def test_delete_row_removes_row(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        inserted = await mock_client.insert_row("agents", {"name": "A"})
+        row_id = str(inserted["row_id"])
+
+        result = await mock_client.delete_row("agents", row_id)
+        assert result.get("success") is True
+
+        query = await mock_client.query_rows("agents", filter={})
+        assert query["total"] == 0
+        assert http_blocker["calls"] == 0
+
+
+class TestListRowsMockMode:
+    @pytest.mark.asyncio
+    async def test_list_rows_paginates(
+        self, mock_client: ZeroDBClient, http_blocker: Dict[str, int]
+    ) -> None:
+        for i in range(5):
+            await mock_client.insert_row("items", {"index": i})
+
+        result = await mock_client.list_rows("items", skip=0, limit=2)
+        assert len(result["rows"]) == 2
+        assert result["total"] == 5
+        assert http_blocker["calls"] == 0
+
+
+class TestRealModeStillHitsHttp:
+    """Guard: supplying credentials MUST still issue HTTP calls."""
+
+    @pytest.mark.asyncio
+    async def test_insert_row_with_credentials_calls_http(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ZERODB_API_KEY", raising=False)
+        monkeypatch.delenv("ZERODB_PROJECT_ID", raising=False)
+        client = ZeroDBClient(api_key="real_key", project_id="proj_real")
+        assert client._mock_mode is False
+
+        called = {"count": 0}
+
+        class _FakeResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> Dict[str, Any]:
+                return {"success": True, "row_id": "real-1"}
+
+        class _FakeAsyncClient:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def __aenter__(self) -> "_FakeAsyncClient":
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            async def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+                called["count"] += 1
+                return _FakeResponse()
+
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+        result = await client.insert_row("agents", {"name": "A"})
+        assert called["count"] == 1
+        assert result["row_id"] == "real-1"


### PR DESCRIPTION
## Summary

P0 show-stopper: `ZeroDBClient` logged \"running in mock mode\" when
credentials were missing but every CRUD method still issued real HTTP
calls to `.../zerodb/mock_project/...`, which 404'd and bubbled up as
500s. Entire Tutorial 01 failed for any workshop attendee without
credentials (agents, agent-memory, marketplace, etc).

- Add `_InMemoryStore` and short-circuit every CRUD path (tables, rows,
  vectors, embeddings) to the store when `_mock_mode` is True.
- Preserve real API calls when credentials ARE provided (guard test
  verifies this).
- Scope supersedes #328 (marketplace-only) — same root cause affected
  every table.

## Before / After

| | Before | After |
| --- | ---: | ---: |
| Workshop E2E checkpoints (developer persona, no creds) | 8/16 | **10/16** |
| Backend pytest failures on this branch | 506 | **500** |
| New tests | — | **14 pass** |

Two new PASSes in the E2E are Tutorial 03 Steps 5 & 6 (marketplace
browse + search) — i.e. the original #328 scope.

The remaining 6 E2E failures are not ZeroDB-related and are covered by
parallel issues:
- Tutorial 01 Step 1, Tutorial 02 Step 1–2: E2E orchestrator POSTs to a
  non-existent `POST /v1/public/projects` endpoint; separate issue.
- Tutorial 02 Step 4, Tutorial 03 Step 3–4: `HederaClient` missing
  `submit_hcs_message` — owned by #322/#327 (parallel work).

## Implementation notes

`ZeroDBClient` now keeps a `_InMemoryStore` instance when credentials
are absent. Each public method has a one-line early return guarded on
`self._mock_mode`:

```python
if self._mock_mode:
    return self._store.insert_row(table_name, row_data)

async with httpx.AsyncClient() as client:
    ...
```

The store supports MongoDB-style `$eq`, `$gt`/`$gte`/`$lt`/`$lte`
filters — enough for current service-layer callers and the workshop
tutorials. IDs are stringified UUIDs so both int-style and UUID-style
lookups from downstream code work.

## Test plan

- [x] `pytest app/tests/test_zerodb_client.py -v` → 14/14 pass
  - Mock-mode insert/query/get/update/delete/list never call httpx
  - Credentialed client still hits HTTPS (guard)
  - Marketplace-listings regression test for #328
- [x] `pytest app/tests/ --ignore=app/tests/test_market_data_tool.py --ignore=app/tests/test_x402_tool.py`
  → 500 failed (main baseline 506 — 6 pre-existing failures fixed, 0 regressions).
  Two skipped files have a pre-existing Py3.9 incompat unrelated to this change.
- [x] Workshop E2E baseline (stashed fix): 8/16
- [x] Workshop E2E with fix: 10/16
- [x] Manual: `POST /v1/public/proj_demo_u1_001/agents` against a seeded
  project returns 201 with full agent payload (previously 500).

Closes #345
Closes #328

Built by AINative Dev Team