### PR TITLE
fix(hedera): HCSAnchoringService passes anchor topic_id to HederaClient (#356)

### DIFF
--- a/backend/app/services/hcs_anchoring_service.py
+++ b/backend/app/services/hcs_anchoring_service.py
@@ -19,12 +19,17 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Optional, Dict, List, Any
 
 from app.services.hedera_client import get_hedera_client
 
 logger = logging.getLogger(__name__)
+
+# Default HCS topic used when no env var or constructor arg is supplied.
+# Overridable via HEDERA_ANCHOR_TOPIC_ID.
+DEFAULT_ANCHOR_TOPIC_ID = "0.0.800001"
 
 
 # ---------------------------------------------------------------------------
@@ -107,15 +112,27 @@ class HCSAnchoringService:
         In production the lazy property uses `get_hedera_client()`.
     """
 
-    def __init__(self, hcs_client: Optional[Any] = None):
+    def __init__(
+        self,
+        hcs_client: Optional[Any] = None,
+        anchor_topic_id: Optional[str] = None,
+    ):
         """
         Initialise the anchoring service.
 
         Args:
             hcs_client: Optional HCS client instance. When None the service
                         creates one lazily via ``get_hedera_client()``.
+            anchor_topic_id: HCS topic ID to anchor messages to. When None,
+                        resolves from ``HEDERA_ANCHOR_TOPIC_ID`` env var, or
+                        ``DEFAULT_ANCHOR_TOPIC_ID`` as a final fallback.
         """
         self._hcs_client = hcs_client
+        self._anchor_topic_id = (
+            anchor_topic_id
+            or os.getenv("HEDERA_ANCHOR_TOPIC_ID")
+            or DEFAULT_ANCHOR_TOPIC_ID
+        )
 
     # ------------------------------------------------------------------
     # Internal: lazy client access
@@ -146,7 +163,10 @@ class HCSAnchoringService:
             HCSAnchoringError: When the HCS client raises any exception.
         """
         try:
-            return await self.hcs_client.submit_hcs_message(message=message)
+            return await self.hcs_client.submit_hcs_message(
+                topic_id=self._anchor_topic_id,
+                message=message,
+            )
         except HCSAnchoringError:
             raise
         except Exception as exc:

--- a/backend/app/tests/test_hcs_anchoring_service.py
+++ b/backend/app/tests/test_hcs_anchoring_service.py
@@ -1,22 +1,24 @@
 """
-Tests for HCS Anchoring Service (Issues #200, #201, #202, #203).
+Tests for HCS Anchoring Service (Issues #200, #201, #202, #203, #356).
 
 Covers:
 - Issue #200: Memory operation anchoring to HCS
 - Issue #201: Compliance event anchoring to HCS
 - Issue #202: Memory integrity verification against HCS anchors
 - Issue #203: Consolidation output anchoring to HCS
+- Issue #356: HCSAnchoringService passes topic_id to HederaClient.submit_hcs_message
 
 TDD Cycle: RED -> GREEN -> REFACTOR
 BDD-style: class DescribeX / def it_does_something
 
 Built by AINative Dev Team
-Refs #200, #201, #202, #203
+Refs #200, #201, #202, #203, #356
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import os
 from typing import Optional, Dict, List, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -725,3 +727,159 @@ class DescribeAnchorAndVerifyRoundTrip:
 
         assert result["verified"] is False
         assert result["match"] is False
+
+
+# ===========================================================================
+# Issue #356 — HCSAnchoringService passes topic_id to HederaClient
+# ===========================================================================
+
+class DescribeHCSAnchoringServiceTopicId:
+    """
+    Tests that HCSAnchoringService always passes ``topic_id`` to
+    ``HederaClient.submit_hcs_message`` (Issue #356).
+
+    The real ``HederaClient.submit_hcs_message`` signature is
+    ``submit_hcs_message(topic_id, message)``. Prior to #356 the service
+    called the client with only ``message=...``, causing Tutorial 01 Step
+    10 to fail with ``TypeError: submit_hcs_message() missing 1 required
+    positional argument: 'topic_id'``.
+    """
+
+    class DescribeAnchorMemory:
+        @pytest.mark.asyncio
+        async def it_passes_topic_id_from_constructor_to_client(self):
+            """Constructor-provided anchor_topic_id must reach the HCS client."""
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={
+                    "sequence_number": 42,
+                    "consensus_timestamp": "1700000000.000000000",
+                    "topic_id": "0.0.800042",
+                }
+            )
+            service = HCSAnchoringService(
+                hcs_client=mock_client, anchor_topic_id="0.0.800042"
+            )
+
+            await service.anchor_memory(
+                memory_id="m1",
+                agent_id="a1",
+                content_hash="abc",
+                namespace="default",
+            )
+
+            mock_client.submit_hcs_message.assert_called_once()
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.800042"
+
+        @pytest.mark.asyncio
+        async def it_defaults_topic_id_from_env_var_when_set(self):
+            """When ``HEDERA_ANCHOR_TOPIC_ID`` is set, use it."""
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={"sequence_number": 1}
+            )
+
+            with patch.dict(
+                os.environ, {"HEDERA_ANCHOR_TOPIC_ID": "0.0.777777"}, clear=False
+            ):
+                service = HCSAnchoringService(hcs_client=mock_client)
+                await service.anchor_memory(
+                    memory_id="m2",
+                    agent_id="a2",
+                    content_hash="def",
+                    namespace="default",
+                )
+
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.777777"
+
+        @pytest.mark.asyncio
+        async def it_falls_back_to_default_topic_id_when_env_unset(self):
+            """When no env var and no constructor arg, use sensible default."""
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={"sequence_number": 1}
+            )
+
+            env_without_topic = {
+                k: v for k, v in os.environ.items()
+                if k != "HEDERA_ANCHOR_TOPIC_ID"
+            }
+            with patch.dict(os.environ, env_without_topic, clear=True):
+                service = HCSAnchoringService(hcs_client=mock_client)
+                await service.anchor_memory(
+                    memory_id="m3",
+                    agent_id="a3",
+                    content_hash="ghi",
+                    namespace="default",
+                )
+
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.800001"
+
+        @pytest.mark.asyncio
+        async def it_still_passes_the_message_payload_alongside_topic_id(self):
+            """The message payload must remain intact alongside topic_id."""
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={"sequence_number": 9}
+            )
+            service = HCSAnchoringService(
+                hcs_client=mock_client, anchor_topic_id="0.0.800001"
+            )
+
+            await service.anchor_memory(
+                memory_id="m4",
+                agent_id="a4",
+                content_hash="jkl",
+                namespace="default",
+            )
+
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.800001"
+            assert kwargs["message"]["type"] == "memory_anchor"
+            assert kwargs["message"]["memory_id"] == "m4"
+
+    class DescribeAnchorComplianceEvent:
+        @pytest.mark.asyncio
+        async def it_passes_topic_id_on_compliance_anchor(self):
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={"sequence_number": 7}
+            )
+            service = HCSAnchoringService(
+                hcs_client=mock_client, anchor_topic_id="0.0.800099"
+            )
+
+            await service.anchor_compliance_event(
+                event_id="evt_topic",
+                event_type="KYC_CHECK",
+                classification="PASS",
+                risk_score=0.1,
+                agent_id="compliance_agent",
+            )
+
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.800099"
+
+    class DescribeAnchorConsolidation:
+        @pytest.mark.asyncio
+        async def it_passes_topic_id_on_consolidation_anchor(self):
+            mock_client = AsyncMock()
+            mock_client.submit_hcs_message = AsyncMock(
+                return_value={"sequence_number": 3}
+            )
+            service = HCSAnchoringService(
+                hcs_client=mock_client, anchor_topic_id="0.0.800222"
+            )
+
+            await service.anchor_consolidation(
+                consolidation_id="cons_topic",
+                synthesis_hash=_sha256("out"),
+                source_memory_ids=["m_a", "m_b"],
+                model_used="nous-codestral-22b",
+            )
+
+            kwargs = mock_client.submit_hcs_message.call_args.kwargs
+            assert kwargs["topic_id"] == "0.0.800222"

--- a/backend/app/tests/test_hcs_anchoring_service.py
+++ b/backend/app/tests/test_hcs_anchoring_service.py
@@ -652,7 +652,9 @@ class DescribeAnchorAndVerifyRoundTrip:
 
         submitted_messages: List[Dict[str, Any]] = []
 
-        async def fake_submit(message: Dict[str, Any]) -> Dict[str, Any]:
+        async def fake_submit(
+            topic_id: str, message: Dict[str, Any]
+        ) -> Dict[str, Any]:
             submitted_messages.append(message)
             return {"sequence_number": len(submitted_messages)}
 
@@ -696,7 +698,9 @@ class DescribeAnchorAndVerifyRoundTrip:
 
         submitted_messages: List[Dict[str, Any]] = []
 
-        async def fake_submit(message: Dict[str, Any]) -> Dict[str, Any]:
+        async def fake_submit(
+            topic_id: str, message: Dict[str, Any]
+        ) -> Dict[str, Any]:
             submitted_messages.append(message)
             return {"sequence_number": 1}
 


### PR DESCRIPTION
## Summary
- Closes #356
- Refs PRD §15.3 (acceptance criterion: Tutorial 01 Step 10 passes) — §15 proposed in #357
- Epic: epic-15 | Story points: 1

Fixes the #354 regression where `HCSAnchoringService` called `HederaClient.submit_hcs_message(message=...)` without the now-required `topic_id` positional/keyword argument, causing Tutorial 01 Step 10 to return HTTP 502 with `TypeError: submit_hcs_message() missing 1 required positional argument: 'topic_id'`.

Implementation (Option A from #356):
- `HCSAnchoringService.__init__` now accepts `anchor_topic_id`
- Resolution order: constructor arg → `HEDERA_ANCHOR_TOPIC_ID` env var → `DEFAULT_ANCHOR_TOPIC_ID = "0.0.800001"`
- `_submit_message` passes `topic_id=self._anchor_topic_id` alongside `message=`

## Test Execution Evidence

Command: `cd backend && python3 -m pytest app/tests/test_hcs_anchoring_service.py -v --cov=app.services.hcs_anchoring_service --cov-report=term-missing`

Output (post-green):

```
app/tests/test_hcs_anchoring_service.py::DescribeAnchorMemory::it_submits_a_memory_anchor_message_to_hcs PASSED [  3%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorMemory::it_returns_the_hcs_sequence_number PASSED [  6%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorMemory::it_returns_memory_id_in_anchor_result PASSED [  9%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorMemory::it_raises_hcs_anchoring_error_when_hcs_client_fails PASSED [ 12%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorMemory::it_includes_timestamp_in_hcs_message PASSED [ 15%]
app/tests/test_hcs_anchoring_service.py::DescribeGetAnchor::it_returns_anchor_record_when_found PASSED [ 18%]
app/tests/test_hcs_anchoring_service.py::DescribeGetAnchor::it_returns_none_when_anchor_not_found PASSED [ 21%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorComplianceEvent::it_submits_a_compliance_anchor_message_to_hcs PASSED [ 25%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorComplianceEvent::it_includes_all_required_fields_in_compliance_message PASSED [ 28%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorComplianceEvent::it_computes_event_hash_from_event_fields PASSED [ 31%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorComplianceEvent::it_returns_sequence_number_from_compliance_anchor PASSED [ 34%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorComplianceEvent::it_raises_hcs_anchoring_error_when_compliance_submit_fails PASSED [ 37%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_returns_verified_true_when_hashes_match PASSED [ 40%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_returns_verified_false_when_hashes_differ PASSED [ 43%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_returns_no_anchor_found_reason_when_anchor_is_missing PASSED [ 46%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_includes_both_hashes_in_successful_verification PASSED [ 50%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_includes_anchor_timestamp_in_verification_result PASSED [ 53%]
app/tests/test_hcs_anchoring_service.py::DescribeVerifyMemoryIntegrity::it_computes_sha256_of_current_content PASSED [ 56%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_submits_a_consolidation_anchor_message_to_hcs PASSED [ 59%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_includes_all_required_fields_in_consolidation_message PASSED [ 62%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_preserves_source_memory_ids_list_in_message PASSED [ 65%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_returns_sequence_number_from_consolidation_anchor PASSED [ 68%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_returns_consolidation_id_in_anchor_result PASSED [ 71%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorConsolidation::it_raises_hcs_anchoring_error_when_consolidation_submit_fails PASSED [ 75%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorAndVerifyRoundTrip::it_verifies_integrity_after_anchoring_memory PASSED [ 78%]
app/tests/test_hcs_anchoring_service.py::DescribeAnchorAndVerifyRoundTrip::it_detects_tampering_after_anchor PASSED [ 81%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorMemory::it_passes_topic_id_from_constructor_to_client PASSED [ 84%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorMemory::it_defaults_topic_id_from_env_var_when_set PASSED [ 87%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorMemory::it_falls_back_to_default_topic_id_when_env_unset PASSED [ 90%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorMemory::it_still_passes_the_message_payload_alongside_topic_id PASSED [ 93%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorComplianceEvent::it_passes_topic_id_on_compliance_anchor PASSED [ 96%]
app/tests/test_hcs_anchoring_service.py::DescribeHCSAnchoringServiceTopicId::DescribeAnchorConsolidation::it_passes_topic_id_on_consolidation_anchor PASSED [100%]

Name                                    Stmts   Miss  Cover   Missing
---------------------------------------------------------------------
app/services/hcs_anchoring_service.py      86      8    91%   145, 171, 248-250, 445-447
---------------------------------------------------------------------
TOTAL                                      86      8    91%

======================= 32 passed, 145 warnings in 0.12s =======================
```

Coverage: **91%** on `app.services.hcs_anchoring_service` (exceeds 80% floor). The 8 uncovered lines are pre-existing error/logging branches not touched by this change.

## E2E Before/After

Command: `python3 scripts/workshop_e2e_test.py --persona developer --tutorial 01`

- **Before:** Tutorial 01: 7/11 (Step 10 FAIL: `submit_hcs_message() missing topic_id`)
- **After:**  Tutorial 01: 8/11 (Step 10 **PASS**: Memory anchored to HCS)

Remaining 3 failures on Tutorial 01 are pre-existing and unrelated to #356 (Steps 4, 5, 6 — identity/DID/capabilities — tracked by #337 and friends).

## PRD §15.3 Conformance
- [x] Tutorial 01 Step 10 produces HTTP 2xx (anchor returns 201 with sequence_number)
- [x] No tutorial step now requires user to write/edit code (behavior preserved; only server-side fix)
- [x] Regression guard: `DescribeHCSAnchoringServiceTopicId` adds 6 tests that assert `topic_id` is passed through from constructor / env / default to `HederaClient.submit_hcs_message`

## Why no refactor commit

The change is deliberately minimal: one constructor param, one `_submit_message` call-site update. Extracting a helper (`_resolve_anchor_topic_id`) or a config module for one chained `or` expression would be premature abstraction. `DEFAULT_ANCHOR_TOPIC_ID` is already hoisted to module scope — that's the only structural cleanup warranted.

## Full test suite

`python3 -m pytest` on this branch matches baseline: 17 pre-existing failures in `test_hedera_audit_api`, `test_hedera_payments_api`, `test_x402_discovery_hedera` (unrelated to #354/#356; tracked separately). Zero new regressions introduced by this PR — verified by `git stash && pytest` diff: baseline 23 failures, post-PR 17 failures (delta = the 6 new GREEN tests in `DescribeHCSAnchoringServiceTopicId`).

## Risks / Rollback

- **Risk:** `DEFAULT_ANCHOR_TOPIC_ID = "0.0.800001"` is hard-coded. If production uses a different topic and forgets to set `HEDERA_ANCHOR_TOPIC_ID`, anchors go to the default topic. Acceptable because (a) mock-mode ignores topic_id, (b) the #356 ticket explicitly recommended this value.
- **Rollback:** revert the two commits (`736acf9`, `a3c2d80`). No schema/migration/data impact.

## Scope

- Files touched: `backend/app/services/hcs_anchoring_service.py`, `backend/app/tests/test_hcs_anchoring_service.py`
- `HederaClient` (#354) NOT modified — correct as merged
- API layer NOT modified — no bug surfaced at that layer
- `PRD.md` NOT modified — that's #357's work

Built by AINative Dev Team