### PR TITLE
fix(hedera): link Hedera identity to existing agent + document required fields (#346)

### DIFF
--- a/backend/app/api/hedera_identity.py
+++ b/backend/app/api/hedera_identity.py
@@ -33,6 +33,7 @@ from app.schemas.hedera_identity import (
     DirectoryRegisterResponse,
     DirectorySearchRequest,
     DIDResolutionResult,
+    LinkedAgentRegisterRequest,
 )
 from app.services.hedera_identity_service import (
     HederaIdentityError,
@@ -205,6 +206,61 @@ async def register_in_directory(
         transaction_id=result.get("transaction_id"),
         did=result.get("did", request.agent_did),
         directory_topic=directory_service.directory_topic_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/hedera/identity/{agent_id}/register (Refs #346)
+#
+# IMPORTANT: this route MUST be declared after `/directory/register` (above)
+# so FastAPI does not match POST /api/v1/hedera/identity/directory/register
+# as agent_id="directory". Routes are tried in registration order.
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{agent_id}/register",
+    status_code=status.HTTP_201_CREATED,
+    response_model=AgentRegisterResponse,
+    responses={
+        201: {"description": "Hedera identity linked to existing agent"},
+        404: {"description": "Agent not found in project store"},
+        422: {"description": "Request schema validation failed"},
+        502: {"description": "Hedera network error"},
+    },
+    summary="Link Hedera HTS NFT identity to an existing agent",
+    description=(
+        "Attaches a Hedera HTS NFT identity to an agent that was previously "
+        "created via POST /v1/public/{project_id}/agents. The response "
+        "preserves the same agent_id, so Tutorial 01 Step 1 and Step 4 refer "
+        "to the SAME agent record. `name` and `role` are pulled from the "
+        "stored agent unless overridden in the request body. Refs #346."
+    ),
+)
+async def register_existing_agent(
+    agent_id: str,
+    request: LinkedAgentRegisterRequest,
+    identity_service: HederaIdentityService = Depends(get_hedera_identity_service),
+) -> AgentRegisterResponse:
+    """Link a Hedera HTS NFT identity to an existing project-store agent."""
+    try:
+        result = await identity_service.register_for_existing_agent(
+            agent_id=agent_id,
+            capabilities=request.capabilities,
+            name=request.name,
+            role=request.role,
+            token_id=request.token_id,
+        )
+    except HederaIdentityError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+    return AgentRegisterResponse(
+        agent_id=result["agent_id"],
+        token_id=result["token_id"],
+        serial_number=result["serial_number"],
+        did=result.get("did"),
+        status=result["status"],
+        transaction_id=result.get("transaction_id"),
     )
 
 

--- a/backend/app/schemas/hedera_identity.py
+++ b/backend/app/schemas/hedera_identity.py
@@ -257,6 +257,37 @@ class DirectoryRegisterResponse(BaseModel):
     directory_topic: str
 
 
+class LinkedAgentRegisterRequest(BaseModel):
+    """
+    Request body for POST /api/v1/hedera/identity/{agent_id}/register (Refs #346).
+
+    Used to attach a Hedera HTS NFT identity to an agent that already exists
+    in the project store (e.g. from POST /v1/public/{project_id}/agents).
+    `name` and `role` are optional — they default to the values stored on the
+    existing agent.
+    """
+    capabilities: List[str] = Field(
+        default_factory=list,
+        description="AAP capabilities to assign to this agent",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Optional override for agent name (defaults to existing agent's name)",
+    )
+    role: Optional[str] = Field(
+        default=None,
+        description="Optional override for agent role (defaults to existing agent's role)",
+    )
+    token_id: Optional[str] = Field(
+        default=None,
+        description="Existing HTS token ID to mint under; creates new class if omitted",
+    )
+    admin_key: Optional[str] = Field(
+        default=None,
+        description="Admin public key hex for new token class creation",
+    )
+
+
 class CapabilitiesUpdateRequest(BaseModel):
     """Request body for PUT /api/v1/hedera/identity/{agent_id}/capabilities."""
     token_id: str

--- a/backend/app/services/hedera_identity_service.py
+++ b/backend/app/services/hedera_identity_service.py
@@ -83,14 +83,19 @@ class HederaIdentityService:
     def __init__(
         self,
         nft_client: Optional[HederaHTSNFTClient] = None,
+        agent_lookup: Optional[Any] = None,
     ):
         """
         Initialize the Hedera Identity Service.
 
         Args:
             nft_client: Optional HTS NFT client (lazy-initialized if None)
+            agent_lookup: Optional async callable `(agent_id) -> Optional[Agent]`
+                used by register_for_existing_agent to resolve a stored agent.
+                Defaults to a lookup against AgentService when None.
         """
         self._nft_client = nft_client
+        self._agent_lookup = agent_lookup
 
     @property
     def nft_client(self) -> HederaHTSNFTClient:
@@ -320,6 +325,80 @@ class HederaIdentityService:
         )
 
     # ------------------------------------------------------------------
+    # Issue #346: Linked agent registration
+    # ------------------------------------------------------------------
+
+    async def register_for_existing_agent(
+        self,
+        agent_id: str,
+        capabilities: List[str],
+        name: Optional[str] = None,
+        role: Optional[str] = None,
+        token_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Attach a Hedera HTS NFT identity to an agent that already exists in
+        the project store.
+
+        Unlike :meth:`mint_agent_nft` (which is invoked by the standalone
+        /register endpoint and generates a fresh agent_id), this method
+        preserves the caller-supplied agent_id so the workshop's "create
+        agent" step (Tutorial 01 Step 1) and "register on Hedera" step
+        (Tutorial 01 Step 4) refer to the SAME agent record.
+
+        Args:
+            agent_id: The pre-existing agent identifier to link
+            capabilities: AAP capabilities to assign
+            name: Optional agent name override (defaults to the stored agent's name)
+            role: Optional agent role override (defaults to the stored agent's role)
+            token_id: Optional HTS token id to mint under
+
+        Returns:
+            Dict with agent_id (same as input), token_id, serial_number, did,
+            status, transaction_id.
+
+        Raises:
+            HederaIdentityError(404): if the agent_id does not exist in the store.
+        """
+        lookup = self._agent_lookup or _default_agent_lookup
+        existing = await lookup(agent_id)
+        if existing is None:
+            raise HederaIdentityError(
+                f"Agent '{agent_id}' not found. Create it first via "
+                f"POST /v1/public/{{project_id}}/agents.",
+                status_code=404,
+            )
+
+        effective_name = name or getattr(existing, "name", "")
+        effective_role = role or getattr(existing, "role", "")
+        effective_token_id = token_id or "0.0.pending"
+        timestamp = datetime.now(timezone.utc).isoformat()
+        did = f"did:hedera:testnet:{agent_id}_pending"
+
+        metadata = {
+            "name": effective_name,
+            "role": effective_role,
+            "did": did,
+            "capabilities": capabilities,
+            "created_at": timestamp,
+            "status": "active",
+        }
+
+        mint_result = await self.mint_agent_nft(
+            token_id=effective_token_id,
+            agent_metadata=metadata,
+        )
+
+        return {
+            "agent_id": agent_id,
+            "token_id": mint_result["token_id"],
+            "serial_number": mint_result["serial_number"],
+            "did": did,
+            "status": mint_result["status"],
+            "transaction_id": mint_result.get("transaction_id"),
+        }
+
+    # ------------------------------------------------------------------
     # Issue #194: AAP Capability Mapping
     # ------------------------------------------------------------------
 
@@ -433,6 +512,37 @@ class HederaIdentityService:
             token_id=token_id, serial_number=serial_number
         )
         return capability in capabilities
+
+
+async def _default_agent_lookup(agent_id: str):
+    """
+    Default lookup used by ``register_for_existing_agent``.
+
+    Resolves an agent by id from the agents store (ZeroDB-backed in production,
+    in-memory mock store in dev/test). Returns ``None`` if the agent does not
+    exist so the caller can return a 404.
+
+    Refs #346
+    """
+    try:
+        from app.services.zerodb_client import get_zerodb_client
+        from app.services.agent_service import AGENTS_TABLE, _row_to_agent
+
+        client = get_zerodb_client()
+        result = await client.query_rows(
+            table_name=AGENTS_TABLE,
+            filter={"agent_id": agent_id},
+            limit=1,
+        )
+        rows = result.get("rows", [])
+        if not rows:
+            return None
+        return _row_to_agent(rows[0])
+    except Exception as exc:
+        logger.warning(
+            "Default agent lookup failed for %s: %s", agent_id, exc
+        )
+        return None
 
 
 # Global service instance

--- a/backend/app/tests/test_hedera_identity_api.py
+++ b/backend/app/tests/test_hedera_identity_api.py
@@ -553,3 +553,195 @@ class DescribeDirectoryRegisterEndpoint:
 
         # HCS14DirectoryError inherits APIError which sets its own status code
         assert response.status_code in (400, 422, 500)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/hedera/identity/{agent_id}/register (Refs #346)
+# ---------------------------------------------------------------------------
+
+
+class DescribeRegisterExistingAgentEndpoint:
+    """
+    POST /api/v1/hedera/identity/{agent_id}/register links a Hedera identity
+    to an existing project agent rather than creating a disconnected one.
+
+    Refs #346
+    """
+
+    def it_returns_201_when_existing_agent_is_linked(self):
+        """Linked register returns 201 when the agent_id exists in the store."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        mock_service = AsyncMock()
+        mock_service.register_for_existing_agent.return_value = {
+            "agent_id": "agent_existing_123",
+            "token_id": "0.0.9999",
+            "serial_number": 1,
+            "did": "did:hedera:testnet:agent_existing_123_pending",
+            "status": "SUCCESS",
+            "transaction_id": "tx_link",
+        }
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/hedera/identity/agent_existing_123/register",
+            json={"capabilities": ["finance", "compliance", "payments"]},
+        )
+
+        assert response.status_code == 201, response.text
+
+    def it_returns_same_agent_id_in_response(self):
+        """The response agent_id matches the one in the URL path (no new id created)."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        mock_service = AsyncMock()
+        mock_service.register_for_existing_agent.return_value = {
+            "agent_id": "agent_same_001",
+            "token_id": "0.0.9999",
+            "serial_number": 1,
+            "did": "did:hedera:testnet:agent_same_001_pending",
+            "status": "SUCCESS",
+            "transaction_id": "tx",
+        }
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/hedera/identity/agent_same_001/register",
+            json={"capabilities": ["finance"]},
+        )
+
+        body = response.json()
+        assert body["agent_id"] == "agent_same_001"
+
+    def it_returns_404_when_agent_does_not_exist(self):
+        """Linked register returns 404 when the agent_id is not found in the store."""
+        from app.api.hedera_identity import get_hedera_identity_service
+        from app.services.hedera_identity_service import HederaIdentityError
+
+        mock_service = AsyncMock()
+        mock_service.register_for_existing_agent.side_effect = HederaIdentityError(
+            "Agent agent_missing not found", status_code=404
+        )
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/hedera/identity/agent_missing/register",
+            json={"capabilities": ["finance"]},
+        )
+
+        assert response.status_code == 404
+
+    def it_does_not_require_name_or_role_in_body(self):
+        """Body with just capabilities is valid — name/role are pulled from the existing agent."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        mock_service = AsyncMock()
+        mock_service.register_for_existing_agent.return_value = {
+            "agent_id": "agent_only_caps",
+            "token_id": "0.0.9999",
+            "serial_number": 1,
+            "did": "did:hedera:testnet:agent_only_caps_pending",
+            "status": "SUCCESS",
+            "transaction_id": "tx",
+        }
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/hedera/identity/agent_only_caps/register",
+            json={"capabilities": ["finance", "compliance", "payments"]},
+        )
+
+        assert response.status_code == 201, response.text
+
+    def it_passes_url_agent_id_to_the_service(self):
+        """The service receives the agent_id from the URL, not generated."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        mock_service = AsyncMock()
+        mock_service.register_for_existing_agent.return_value = {
+            "agent_id": "agent_passthrough",
+            "token_id": "0.0.1",
+            "serial_number": 1,
+            "did": "did:hedera:testnet:agent_passthrough_pending",
+            "status": "SUCCESS",
+            "transaction_id": None,
+        }
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        client.post(
+            "/api/v1/hedera/identity/agent_passthrough/register",
+            json={"capabilities": ["chat"]},
+        )
+
+        mock_service.register_for_existing_agent.assert_awaited_once()
+        kwargs = mock_service.register_for_existing_agent.call_args.kwargs
+        assert kwargs["agent_id"] == "agent_passthrough"
+        assert kwargs["capabilities"] == ["chat"]
+
+
+class DescribeStandaloneRegisterEndpointBackwardCompat:
+    """
+    Refs #346 — regression: the existing standalone /register endpoint must
+    keep working with `name` + `role` required (no breaking change).
+    """
+
+    def it_still_requires_name_and_role(self):
+        """Backward compat: standalone /register still 422s without name/role."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: AsyncMock()
+
+        client = TestClient(app)
+        # Missing both name and role
+        response = client.post(
+            "/api/v1/hedera/identity/register",
+            json={"capabilities": ["chat"], "token_id": "0.0.9999"},
+        )
+        assert response.status_code == 422
+
+    def it_still_creates_a_standalone_identity(self):
+        """Backward compat: standalone /register still mints with a generated agent_id."""
+        from app.api.hedera_identity import get_hedera_identity_service
+
+        mock_service = AsyncMock()
+        mock_service.mint_agent_nft.return_value = {
+            "serial_number": 1,
+            "token_id": "0.0.9999",
+            "transaction_id": "tx_standalone",
+            "status": "SUCCESS",
+        }
+
+        app = _make_test_app()
+        app.dependency_overrides[get_hedera_identity_service] = lambda: mock_service
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/hedera/identity/register",
+            json={
+                "name": "Backward Compat Agent",
+                "role": "analyst",
+                "capabilities": ["chat"],
+                "token_id": "0.0.9999",
+            },
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["agent_id"].startswith("agent_")
+        assert "token_id" in body

--- a/backend/app/tests/test_hedera_identity_service.py
+++ b/backend/app/tests/test_hedera_identity_service.py
@@ -582,3 +582,178 @@ class DescribeCheckCapability:
                 serial_number=1,
                 capability="fly_to_the_moon",
             )
+
+
+# ---------------------------------------------------------------------------
+# Issue #346: Linked agent registration (link Hedera identity to existing agent)
+# ---------------------------------------------------------------------------
+
+
+class DescribeRegisterForExistingAgent:
+    """
+    HederaIdentityService.register_for_existing_agent links a Hedera identity
+    to an existing project-store agent rather than creating a disconnected one.
+
+    Refs #346
+    """
+
+    @pytest.mark.asyncio
+    async def it_returns_the_same_agent_id_that_was_passed_in(self):
+        """The response agent_id matches the agent_id passed in (no new id minted)."""
+        from app.services.hedera_identity_service import HederaIdentityService
+
+        mock_nft = AsyncMock()
+        mock_nft.mint_nft.return_value = {
+            "serial_number": 1,
+            "token_id": "0.0.9999",
+            "transaction_id": "tx_mint_existing",
+            "status": "SUCCESS",
+        }
+
+        async def fake_lookup(agent_id):
+            return type("Agent", (), {
+                "id": agent_id,
+                "name": "existing-agent-name",
+                "role": "analyst",
+            })()
+
+        service = HederaIdentityService(
+            nft_client=mock_nft, agent_lookup=fake_lookup
+        )
+        result = await service.register_for_existing_agent(
+            agent_id="agent_existing_001",
+            capabilities=["chat", "memory"],
+            token_id="0.0.9999",
+        )
+
+        assert result["agent_id"] == "agent_existing_001"
+
+    @pytest.mark.asyncio
+    async def it_uses_existing_agent_name_and_role_when_not_provided(self):
+        """When name/role omitted, the service pulls them from the existing agent record."""
+        from app.services.hedera_identity_service import HederaIdentityService
+
+        mock_nft = AsyncMock()
+        mock_nft.mint_nft.return_value = {
+            "serial_number": 7,
+            "token_id": "0.0.4242",
+            "transaction_id": "tx",
+            "status": "SUCCESS",
+        }
+
+        async def fake_lookup(agent_id):
+            return type("Agent", (), {
+                "id": agent_id,
+                "name": "stored-agent-name",
+                "role": "compliance",
+            })()
+
+        service = HederaIdentityService(
+            nft_client=mock_nft, agent_lookup=fake_lookup
+        )
+        await service.register_for_existing_agent(
+            agent_id="agent_xyz",
+            capabilities=["compliance"],
+            token_id="0.0.4242",
+        )
+
+        # Inspect the metadata passed to mint_nft
+        call_kwargs = mock_nft.mint_nft.call_args.kwargs
+        metadata_bytes = call_kwargs["metadata_bytes"]
+        import json
+        decoded = json.loads(metadata_bytes.decode("utf-8"))
+        assert decoded["name"] == "stored-agent-name"
+        assert decoded["role"] == "compliance"
+
+    @pytest.mark.asyncio
+    async def it_raises_404_identity_error_when_agent_not_found(self):
+        """register_for_existing_agent raises HederaIdentityError(404) when agent unknown."""
+        from app.services.hedera_identity_service import (
+            HederaIdentityService,
+            HederaIdentityError,
+        )
+
+        async def fake_lookup(agent_id):
+            return None
+
+        service = HederaIdentityService(
+            nft_client=AsyncMock(), agent_lookup=fake_lookup
+        )
+        with pytest.raises(HederaIdentityError) as exc_info:
+            await service.register_for_existing_agent(
+                agent_id="agent_does_not_exist",
+                capabilities=["chat"],
+                token_id="0.0.9999",
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def it_uses_provided_name_when_supplied(self):
+        """When name is explicitly provided, it overrides the stored agent name."""
+        from app.services.hedera_identity_service import HederaIdentityService
+
+        mock_nft = AsyncMock()
+        mock_nft.mint_nft.return_value = {
+            "serial_number": 1,
+            "token_id": "0.0.9999",
+            "transaction_id": "tx",
+            "status": "SUCCESS",
+        }
+
+        async def fake_lookup(agent_id):
+            return type("Agent", (), {
+                "id": agent_id,
+                "name": "stored-name",
+                "role": "analyst",
+            })()
+
+        service = HederaIdentityService(
+            nft_client=mock_nft, agent_lookup=fake_lookup
+        )
+        await service.register_for_existing_agent(
+            agent_id="agent_001",
+            capabilities=["chat"],
+            name="overridden-name",
+            token_id="0.0.9999",
+        )
+
+        import json
+        decoded = json.loads(
+            mock_nft.mint_nft.call_args.kwargs["metadata_bytes"].decode("utf-8")
+        )
+        assert decoded["name"] == "overridden-name"
+
+    @pytest.mark.asyncio
+    async def it_returns_token_id_serial_and_did_in_response(self):
+        """Response includes token_id, serial_number, did, status — same shape as /register."""
+        from app.services.hedera_identity_service import HederaIdentityService
+
+        mock_nft = AsyncMock()
+        mock_nft.mint_nft.return_value = {
+            "serial_number": 3,
+            "token_id": "0.0.7777",
+            "transaction_id": "tx_id",
+            "status": "SUCCESS",
+        }
+
+        async def fake_lookup(agent_id):
+            return type("Agent", (), {
+                "id": agent_id,
+                "name": "n",
+                "role": "r",
+            })()
+
+        service = HederaIdentityService(
+            nft_client=mock_nft, agent_lookup=fake_lookup
+        )
+        result = await service.register_for_existing_agent(
+            agent_id="agent_abc",
+            capabilities=["payment"],
+            token_id="0.0.7777",
+        )
+
+        assert result["token_id"] == "0.0.7777"
+        assert result["serial_number"] == 3
+        assert result["status"] == "SUCCESS"
+        assert "did" in result
+        assert result["did"].startswith("did:hedera:")

--- a/docs/workshop/tutorials/01-identity-and-memory.md
+++ b/docs/workshop/tutorials/01-identity-and-memory.md
@@ -82,29 +82,33 @@ This teaches you the API surface. Your AI will explain: create, list, get, updat
 
 Tell your AI:
 
-> "Register my agent on Hedera using `POST http://localhost:8000/api/v1/hedera/identity/register`. My agent_id is `{agent_id}`. Give it capabilities: `finance`, `compliance`, `payments`."
+> "Register my agent on Hedera using `POST http://localhost:8000/api/v1/hedera/identity/{agent_id}/register` — replace `{agent_id}` with the ID I saved in Step 1. Give it capabilities: `finance`, `compliance`, `payments`."
+
+> 💡 **Your `agent_id` from Step 1 is reused here.** This endpoint *links* a Hedera identity to the agent you already created — Step 1 and Step 4 refer to the SAME agent record. The response will echo back the same `agent_id`.
 
 **Request body example:**
 ```json
 {
-  "agent_id": "{agent_id}",
   "capabilities": ["finance", "compliance", "payments"]
 }
 ```
 
-✅ **You should see:**
+That's it — `name` and `role` are pulled from the agent you created in Step 1, so you don't need to repeat them.
+
+✅ **You should see** (note the `agent_id` matches the one from Step 1):
 ```json
 {
+  "agent_id": "agent_abc123...",
   "token_id": "0.0.XXXXX",
   "serial_number": 1,
-  "agent_did": "did:hedera:testnet:0.0.XXXXX_0.0.YYYYY",
-  "status": "registered"
+  "did": "did:hedera:testnet:agent_abc123..._pending",
+  "status": "SUCCESS"
 }
 ```
 
-📌 **Save your `agent_did`** — this is your agent's decentralized identity. It starts with `did:hedera:testnet:`.
+📌 **Save your `did`** — this is your agent's decentralized identity. It starts with `did:hedera:testnet:`.
 
-**Verification:** Your agent now has an HTS NFT on Hedera testnet. This NFT IS your agent's identity — portable, verifiable, revocable.
+**Verification:** Your agent now has an HTS NFT on Hedera testnet linked to the same `agent_id` you saw in Step 1. This NFT IS your agent's identity — portable, verifiable, revocable.
 
 ---
 

--- a/scripts/workshop_e2e_test.py
+++ b/scripts/workshop_e2e_test.py
@@ -379,47 +379,71 @@ def run_tutorial_01(result: TestResult, persona: str) -> None:
     passed = checkpoint(ok, "Agent appears in list", detail)
     result.record(3, "List agents", passed, detail, time.time() - t0)
 
-    # Step 4: Register identity on Hedera
-    step(4, "Register agent identity on Hedera HTS NFT")
+    # Step 4: Register identity on Hedera (linked to existing agent_id from Step 1)
+    # Refs #346 — uses POST /api/v1/hedera/identity/{agent_id}/register so the
+    # Hedera HTS NFT identity is attached to the SAME agent created in Step 1.
+    step(4, "Register agent identity on Hedera HTS NFT (linked)")
     if persona == "vibe-coder":
         prompt_as_vibe_coder(
-            f"Register my agent on Hedera using POST /api/v1/hedera/identity/register "
-            f"with agent_id {agent_id} and capabilities [finance, compliance, payments]."
+            f"Register my agent on Hedera using POST /api/v1/hedera/identity/{agent_id}/register "
+            f"with capabilities [finance, compliance, payments]."
         )
     t0 = time.time()
     ok, data, detail = api_post(
-        "/api/v1/hedera/identity/register",
+        f"/api/v1/hedera/identity/{agent_id}/register",
         {
-            "agent_id": agent_id,
-            "agent_name": "my-consensus-agent",
             "capabilities": ["finance", "compliance", "payments"],
-            "role": "analyst",
         },
-        expected_status=200,
+        expected_status=201,
     )
     agent_did = None
     token_id = None
+    serial_number = None
     if ok and isinstance(data, dict):
-        agent_did = data.get("agent_did") or data.get("did")
+        agent_did = data.get("did") or data.get("agent_did")
         token_id = data.get("token_id")
+        serial_number = data.get("serial_number")
+        # Sanity check: response must echo the input agent_id.
+        if data.get("agent_id") and data["agent_id"] != agent_id:
+            ok = False
+            detail = (
+                f"agent_id mismatch: sent {agent_id}, got {data['agent_id']}"
+            )
     passed = checkpoint(
         ok,
-        "Hedera identity registered",
-        detail or f"token_id={token_id}, agent_did={agent_did}",
+        "Hedera identity registered (linked to agent from Step 1)",
+        detail or f"token_id={token_id}, did={agent_did}",
     )
-    result.record(4, "Register Hedera identity", passed, detail or f"token_id={token_id}", time.time() - t0)
+    result.record(
+        4,
+        "Register Hedera identity (linked)",
+        passed,
+        detail or f"token_id={token_id}, did={agent_did}",
+        time.time() - t0,
+    )
 
-    # Step 5: Resolve DID
+    # Step 5: Resolve DID — uses the same agent_id (cascade-fixed by #346)
     step(5, "Resolve agent DID")
     t0 = time.time()
     ok, data, detail = api_get(f"/api/v1/hedera/identity/{agent_id}/did")
     passed = checkpoint(ok, "Agent DID resolvable", detail)
     result.record(5, "Resolve DID", passed, detail, time.time() - t0)
 
-    # Step 6: Get capabilities
+    # Step 6: Get capabilities — token_id and serial_number from Step 4
+    # The capabilities endpoint requires token_id + serial_number as query params.
     step(6, "Get agent capabilities")
     t0 = time.time()
-    ok, data, detail = api_get(f"/api/v1/hedera/identity/{agent_id}/capabilities")
+    if token_id and serial_number is not None:
+        ok, data, detail = api_get(
+            f"/api/v1/hedera/identity/{agent_id}/capabilities"
+            f"?token_id={token_id}&serial_number={serial_number}"
+        )
+    else:
+        ok, data, detail = (
+            False,
+            None,
+            "No token_id/serial_number from Step 4",
+        )
     passed = checkpoint(ok, "Agent capabilities retrievable", detail)
     result.record(6, "Get capabilities", passed, detail, time.time() - t0)
 


### PR DESCRIPTION
## Summary
- Closes #346
- Refs PRD §15.3 (acceptance criteria: Tutorial 01 Steps 4, 5, 6 produce HTTP 2xx)
- Epics: epic-10 + epic-15 | Story points: 3

Adds a new `POST /api/v1/hedera/identity/{agent_id}/register` endpoint that
attaches a Hedera HTS NFT identity to an agent already created via
`POST /v1/public/{project_id}/agents` — the response preserves the same
`agent_id`, so Tutorial 01 Step 1 and Step 4 refer to the SAME agent record
(prior behavior in `/register` generated a fresh, disconnected `agent_id`).

The pre-existing standalone `POST /api/v1/hedera/identity/register` is
unchanged (regression tests added in
`DescribeStandaloneRegisterEndpointBackwardCompat`).

## Test Execution Evidence

Command:
```
python3 -m pytest backend/app/tests/test_hedera_identity_api.py backend/app/tests/test_hedera_identity_service.py -v --cov=app.api.hedera_identity --cov=app.services.hedera_identity_service --cov-report=term-missing
```

Output (post-green, last lines):
```
app/tests/test_hedera_identity_service.py::DescribeRegisterForExistingAgent::it_returns_the_same_agent_id_that_was_passed_in PASSED [ 92%]
app/tests/test_hedera_identity_service.py::DescribeRegisterForExistingAgent::it_uses_existing_agent_name_and_role_when_not_provided PASSED [ 94%]
app/tests/test_hedera_identity_service.py::DescribeRegisterForExistingAgent::it_raises_404_identity_error_when_agent_not_found PASSED [ 96%]
app/tests/test_hedera_identity_service.py::DescribeRegisterForExistingAgent::it_uses_provided_name_when_supplied PASSED [ 98%]
app/tests/test_hedera_identity_service.py::DescribeRegisterForExistingAgent::it_returns_token_id_serial_and_did_in_response PASSED [100%]

================================ tests coverage ================================
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
app/api/hedera_identity.py                   69      6    91%   121-122, 163-164, 301-302
app/services/hedera_identity_service.py     115     18    84%   185, 187, 189, 238-240, 527-545, 559
-----------------------------------------------------------------------
TOTAL                                       184     24    87%
======================= 57 passed, 148 warnings in 0.32s =======================
```

All 12 new tests pass; 57/57 hedera_identity tests pass overall; combined api+service coverage = 87% (≥ 80%).

Command (full backend suite, no regressions from this PR):
```
python3 -m pytest backend/app/tests/ --ignore=backend/app/tests/test_market_data_tool.py --ignore=backend/app/tests/test_x402_tool.py
```

Output (last lines):
```
==== 498 failed, 2817 passed, 31 skipped, 990 warnings, 81 errors in 41.99s ====
```

The 498 failures and 81 errors are **pre-existing** on `main` (verified by `git stash` of this PR's changes and re-running); none touch `hedera_identity.py` or `hedera_identity_service.py`. The two skipped collection files (`test_market_data_tool.py`, `test_x402_tool.py`) fail to collect on Python 3.9 because of `type[X] | None` syntax in `tools/__init__.py` — also pre-existing and unrelated.

## E2E Before/After

Tutorial 01, developer persona (`python3 scripts/workshop_e2e_test.py --tutorial 01`):

| | Before | After |
| --- | --- | --- |
| Step 4 (Hedera register) | FAIL (422 — wrong body) | **PASS (201)** |
| Step 5 (Resolve DID) | FAIL | FAIL (separate bug — see below) |
| Step 6 (Get capabilities) | FAIL (422 — missing token_id/serial_number) | **PASS (200)** |
| Total | 7/11 | **9/11** |

### Step 5 is a distinct bug — separate issue recommended
`GET /api/v1/hedera/identity/{agent_id}/did` constructs a fake DID
`did:hedera:testnet:{agent_id}_0.0.1` when no `?did=` query param is supplied,
and there is no agent→DID storage today, so the DID resolver 404s. This needs
either (a) a stored mapping populated by `register_for_existing_agent`, or (b)
the handler accepting `agent_id` and looking up the registered NFT's DID. Out
of scope for #346 — recommend a follow-up issue.

### Step 10 (HCS anchor) is being fixed in parallel under #356.

## PRD §15.3 Conformance
- [x] Tutorial 01 Step 4 produces HTTP 2xx
- [ ] Tutorial 01 Step 5 produces HTTP 2xx — separate issue (see above)
- [x] Tutorial 01 Step 6 produces HTTP 2xx (cascade-fixed by passing token_id+serial_number from Step 4)
- [x] No tutorial step requires user to write/edit code (Step 4 prompt is natural-language only)
- [x] Vibe-coder prompt stays natural language (orchestrator's vibe-coder branch updated to match)

## Risks / Rollback
- **Backward compatibility**: existing `POST /api/v1/hedera/identity/register`
  is unmodified — `name` + `role` still required, response shape unchanged,
  fresh `agent_id` still generated.
  Regression covered by `DescribeStandaloneRegisterEndpointBackwardCompat::*`.
- **Route ordering**: the new `/{agent_id}/register` is a templated POST that
  would shadow `/directory/register` if declared first. It is intentionally
  declared AFTER `/directory/register` in `hedera_identity.py`; an inline
  comment explains why. All existing `DescribeDirectoryRegisterEndpoint` tests
  still pass after this change.
- **Rollback**: revert the three commits (`68d5f64`, `4f9cdd4`, `481b56b`).
  No DB migrations, no schema breaks, no env changes.

Built by AINative Dev Team