### PR TITLE
docs(prd): add §15 Workshop Curriculum Readiness (Consensus 2026)

### DIFF
--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -349,6 +349,73 @@ It positions AINative as foundational infrastructure for:
 
 ---
 
+## 15. Workshop Curriculum Readiness (Consensus 2026)
+
+Agent-402 ships with a workshop curriculum targeting **Consensus 2026**. The curriculum is a first-class deliverable of the MVP and is subject to the same acceptance-criteria discipline as the code.
+
+### 15.1 Scope
+
+Three 50-minute tutorials, each runnable against `localhost:8000` in the workshop's default mock mode:
+
+1. `docs/workshop/tutorials/01-identity-and-memory.md` — agent creation, Hedera identity (HTS NFT + did:hedera), cognitive memory (remember/recall/reflect), HCS anchor
+2. `docs/workshop/tutorials/02-payments-and-trust.md` — Hedera wallets, USDC association, USDC payments, payment verification, reputation feedback
+3. `docs/workshop/tutorials/03-discovery-and-marketplace.md` — HCS-14 directory, HCS-10 messaging, marketplace publish/browse/search
+
+Supporting materials:
+- `docs/workshop/VIBE_CODER_GUIDE.md` — prerequisites, setup, AI-assistant patterns
+- `docs/workshop/GLOSSARY.md` — plain-English definitions of all Hedera/Agent-402 terminology
+- `docs/workshop/TROUBLESHOOTING.md` — common errors and recovery
+- `scripts/workshop_e2e_test.py` — automated checkpoint orchestrator
+- `scripts/workshop_smoke_test.py` — pre-workshop sanity check
+
+### 15.2 Personas (binding)
+
+- **Developer** — may run commands, inspect files, debug. Expected to complete all 3 tutorials in 90 minutes.
+- **Vibe Coder** — natural-language prompts to an AI assistant only; MUST NOT write code, edit files, or run bash directly. Expected to complete all 3 tutorials in 120 minutes.
+
+A tutorial step that forces a vibe coder to break persona (write code, edit files, run bash) is a **curriculum defect** and MUST be rewritten.
+
+### 15.3 Acceptance Criteria
+
+- [ ] `python3 scripts/workshop_e2e_test.py --persona developer --tutorial all` exits 0 with **≥ 95%** of checkpoints passing
+- [ ] `python3 scripts/workshop_e2e_test.py --persona vibe-coder --tutorial all` matches the developer checkpoint count
+- [ ] No tutorial step requires a vibe-coder to write or edit code (persona integrity)
+- [ ] All tutorial steps return HTTP 2xx in mock mode — no ZeroDB or Hedera credentials required for the happy path
+- [ ] `GET /.well-known/x402` includes Hedera metadata (usdc_token_id, mirror_node_url, supported_dids)
+- [ ] `GET /anchor/{memory_id}/verify` returns accurate results — `verified: true` only when the anchor matches; `verified: false` for unknown or fabricated transaction_ids (no false positives)
+- [ ] Each tutorial opens with a prerequisites block linking to `VIBE_CODER_GUIDE.md` and `GLOSSARY.md`
+- [ ] Each step includes: a natural-language vibe-coder prompt, an expected JSON response block, a ✅ self-verification callout
+- [ ] All documented API paths match registered FastAPI routes (enforced by the orchestrator's checkpoints and by `scripts/workshop_smoke_test.py`)
+
+### 15.4 Recordings
+
+- [ ] `asciinema` cast of developer run, total wall time ≤ 10 minutes
+- [ ] `asciinema` cast of vibe-coder run, total wall time ≤ 12 minutes
+- [ ] Both casts uploaded to asciinema.org with URLs in the top-level README and Luma event page
+- [ ] At least one 2×-speed `agg`-rendered GIF ≤ 5 minutes embedded on the Luma event page
+
+### 15.5 Regression Guards
+
+- [ ] `scripts/workshop_smoke_test.py` exits 0 before every release tagged `consensus-2026-*`
+- [ ] CI runs `scripts/workshop_e2e_test.py --persona developer --tutorial all` on every PR that changes `backend/app/`, `docs/workshop/`, or `scripts/workshop_*`
+- [ ] Root `pytest.ini` preserves AINative BDD collection (`Describe*` classes, `it_*` functions) so workshop test suites collect
+- [ ] New Hedera/ZeroDB client code paths MUST include regression tests against the checkpoints in 15.3
+- [ ] Any PR that adds, renames, or removes an API route touched by the tutorials MUST update the corresponding tutorial step in the same PR
+
+### 15.6 Change-Control
+
+Any change that risks a §15.3 acceptance criterion — regardless of intent — requires:
+
+1. The PR body references PRD §15.3 and calls out which criterion is affected
+2. A before/after run of `scripts/workshop_e2e_test.py --persona developer --tutorial all` pasted in the PR body
+3. If a checkpoint regresses: either the regression is fixed in the same PR, or a follow-up `bug/` issue is filed and linked **before merge**
+
+### 15.7 Current State (as of 2026-04-20)
+
+Live workshop status is tracked in `docs/workshop/test-results/CURRICULUM_WALKTHROUGH_20260419.md` and in open issues labelled with `epic-10` or `epic-15`. Baseline at this PRD version: **24/28 checkpoints passing (86%)**. Open issues to close before Consensus 2026: #337, #342, #346, #347, #348, #353, #356.
+
+---
+
 ## Final Framing (Judges & Investors)
 
 > **“We didn’t build a demo.


### PR DESCRIPTION
## Summary

Closes #357. Adds PRD §15 codifying the workshop curriculum as a first-class MVP deliverable with binding acceptance criteria.

Now the three in-flight Hedera/workshop PRs (#358, #359, #349) — and every future workshop-adjacent PR — have a concrete PRD section to reference in their body, not just an open issue.

## What lands

- **§15.1 Scope** — three 50-min tutorials + supporting docs + orchestrator + smoke test
- **§15.2 Personas** — developer (90 min) and vibe coder (120 min, natural language only). Persona break = curriculum defect.
- **§15.3 Acceptance Criteria** — ≥ 95% E2E checkpoints, HTTP 2xx in mock mode, no vibe-coder code-writing, no false-positive verifies, prerequisites/response/✅ blocks per step
- **§15.4 Recordings** — asciinema casts + 2× GIF for Luma page
- **§15.5 Regression Guards** — smoke test before release, CI on workshop changes, pytest BDD collection preserved, regression tests required
- **§15.6 Change-Control** — PRs risking §15.3 MUST reference the criterion + paste before/after E2E + file follow-up before merge
- **§15.7 Current State** — 24/28 baseline (86%); open blockers listed

## Why now

Before this, `docs/product/PRD.md` had zero workshop mention. Twelve issues filed this session (#325–#357) had no PRD section to anchor to. Cody-TDD spawn prompts referenced "§15 (proposed)" — now that becomes "§15 (authoritative)".

## Test plan

- [x] `docs/product/PRD.md` renders correctly on GitHub
- [x] Cross-references validate: #357, #337, #342, #346, #347, #348, #353, #356
- [x] Files/paths in §15.1 all exist in repo
- [x] Acceptance criteria in §15.3 are all objectively testable

## Refs

- Closes #357
- Referenced by in-flight PRs: #358 (#356), #359 (#346), #349 (#342)
- Labels: epic-10, 3-points, documentation

Built by AINative Dev Team