### PR TITLE
docs(workshop): add SETUP.md and fix tutorial prerequisite sections

### DIFF
--- a/docs/workshop/SETUP.md
+++ b/docs/workshop/SETUP.md
@@ -1,0 +1,122 @@
+# Workshop Setup Guide
+
+Complete this guide before starting any tutorial. Every tutorial assumes a running server with workshop mode enabled.
+
+**Time:** ~15 minutes
+
+---
+
+## Step 1: Clone and Install
+
+```bash
+git clone https://github.com/AINative-Studio/Agent-402.git
+cd Agent-402
+cp .env.example .env
+pip3 install -r requirements.txt
+```
+
+---
+
+## Step 2: Add Your Credentials to `.env`
+
+Open `.env` and fill in the following values.
+
+### Hedera Testnet Account
+
+Get a free testnet account at https://portal.hedera.com (takes ~2 minutes).
+
+```bash
+HEDERA_OPERATOR_ID=0.0.XXXXX
+HEDERA_OPERATOR_KEY=your_private_key_here
+HEDERA_NETWORK=testnet
+```
+
+### ZeroDB API Key
+
+Sign in at https://ainative.studio/developer-settings, create a project, and generate an API key.
+
+```bash
+ZERODB_API_KEY=ZDB_XXXXXXXXXXXX
+ZERODB_PROJECT_ID=proj_YYYYYYYY
+```
+
+### Workshop Mode
+
+These two lines activate the URL rewriting middleware that maps the tutorial-style paths
+(`/api/v1/...`) to the real API routes (`/v1/public/{project_id}/...`). Without them,
+every tutorial API call returns a 404.
+
+```bash
+WORKSHOP_MODE=true
+WORKSHOP_DEFAULT_PROJECT_ID=proj_workshop
+```
+
+Set `WORKSHOP_DEFAULT_PROJECT_ID` to the same value as your `ZERODB_PROJECT_ID` so that
+requests are routed to your actual project.
+
+---
+
+## Step 3: Start the Server
+
+```bash
+cd backend
+uvicorn app.main:app --reload --port 8000
+```
+
+**Verify it's running:**
+
+```bash
+curl http://localhost:8000/health
+# → {"status": "healthy"}
+```
+
+You can also open http://localhost:8000/docs in your browser to see the full API reference.
+
+If you see an error, paste it to your AI assistant:
+
+> "I got this error starting the Agent-402 server: [paste error]. Help me fix it."
+
+---
+
+## Step 4: Confirm Workshop Mode Is Active
+
+```bash
+curl -H "X-API-Key: demo_key_user1_abc123" \
+     http://localhost:8000/api/v1/agents
+```
+
+You should receive a `200` with a JSON list (empty is fine). A `404` means
+`WORKSHOP_MODE=true` is not set — check your `.env` and restart the server.
+
+---
+
+## Step 5: Run the Smoke Test
+
+```bash
+python scripts/workshop_smoke_test.py
+```
+
+All checks should pass. If any fail, paste the output to your AI assistant.
+
+---
+
+## You're Ready
+
+Start with Tutorial 1 and work through them in order:
+
+1. [Tutorial 1: Identity & Memory](tutorials/01-identity-and-memory.md)
+2. [Tutorial 2: Payments & Trust](tutorials/02-payments-and-trust.md)
+3. [Tutorial 3: Discovery & Marketplace](tutorials/03-discovery-and-marketplace.md)
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `Connection refused` on any API call | Server not running | Run `uvicorn app.main:app --reload --port 8000` from `backend/` |
+| `404` on `/api/v1/...` paths | `WORKSHOP_MODE` not set | Add `WORKSHOP_MODE=true` to `.env`, restart server |
+| `500` on memory/vector calls | Bad ZeroDB credentials | Check `ZERODB_API_KEY` and `ZERODB_PROJECT_ID` in `.env` |
+| `PROJECT_NOT_FOUND` | `WORKSHOP_DEFAULT_PROJECT_ID` mismatch | Set it to the same value as `ZERODB_PROJECT_ID` |
+
+For more help, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).

--- a/docs/workshop/tutorials/01-identity-and-memory.md
+++ b/docs/workshop/tutorials/01-identity-and-memory.md
@@ -3,10 +3,31 @@
 **Time:** ~50 minutes  
 **Goal:** Create an agent with a Hedera identity and persistent, tamper-proof memory
 
-> **Before you start:** Make sure your server is running and your `ZERODB_PROJECT_ID` is set.
+## Prerequisites
+
+Complete **[SETUP.md](../SETUP.md)** before starting this tutorial. You need:
+
+- The backend server running on `http://localhost:8000`
+- `WORKSHOP_MODE=true` in your `.env` (otherwise all API calls return 404)
+- `WORKSHOP_DEFAULT_PROJECT_ID` set to your ZeroDB project ID
+- ZeroDB credentials (`ZERODB_API_KEY`, `ZERODB_PROJECT_ID`) in your `.env`
+
+**Quick check — run this before Step 1:**
+
+```bash
+curl http://localhost:8000/health
+# → {"status": "healthy"}
+```
+
+If you see `Connection refused`, start the server first:
+
+```bash
+cd backend
+uvicorn app.main:app --reload --port 8000
+```
+
 > Every URL in this tutorial contains `{project_id}` — replace it with the value of
 > `ZERODB_PROJECT_ID` from your `.env` file (e.g. `proj_workshop`).
-> See the [Vibe Coder Guide](../VIBE_CODER_GUIDE.md) for setup steps.
 > New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 
 ---

--- a/docs/workshop/tutorials/02-payments-and-trust.md
+++ b/docs/workshop/tutorials/02-payments-and-trust.md
@@ -3,11 +3,29 @@
 **Time:** ~50 minutes  
 **Goal:** Execute USDC payments on Hedera and build an on-chain reputation
 
-**Prerequisite:** Completed Tutorial 1 — you have an `agent_id` (e.g. `agent_abc123...`) and an `agent_did` (e.g. `did:hedera:testnet:0.0.XXXXX_0.0.YYYYY`).
+## Prerequisites
 
-> **Before you start:** Every URL containing `{project_id}` requires your `ZERODB_PROJECT_ID` from `.env`
-> (e.g. `proj_workshop`). See the [Vibe Coder Guide](../VIBE_CODER_GUIDE.md) if you haven't set this up.
-> New to Hedera terms? See the [Glossary](../GLOSSARY.md).
+- Completed [Tutorial 1: Identity & Memory](01-identity-and-memory.md) — you have an `agent_id` and an `agent_did`
+- Server still running on `http://localhost:8000` with `WORKSHOP_MODE=true`
+
+If you closed your terminal since Tutorial 1, restart the server:
+
+```bash
+cd backend
+uvicorn app.main:app --reload --port 8000
+```
+
+Then verify:
+
+```bash
+curl http://localhost:8000/health
+# → {"status": "healthy"}
+```
+
+If the server is not running or `WORKSHOP_MODE=true` is missing from `.env`, see [SETUP.md](../SETUP.md).
+
+> Every URL containing `{project_id}` requires your `ZERODB_PROJECT_ID` from `.env`
+> (e.g. `proj_workshop`). New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 
 ---
 

--- a/docs/workshop/tutorials/03-discovery-and-marketplace.md
+++ b/docs/workshop/tutorials/03-discovery-and-marketplace.md
@@ -3,7 +3,26 @@
 **Time:** ~50 minutes  
 **Goal:** Publish your agent, discover others, and coordinate a multi-agent workflow
 
-**Prerequisite:** Completed Tutorials 1 & 2 — you have `agent_id`, `agent_did`, and a payment history.
+## Prerequisites
+
+- Completed [Tutorial 1](01-identity-and-memory.md) and [Tutorial 2](02-payments-and-trust.md) — you have `agent_id`, `agent_did`, and a payment history
+- Server still running on `http://localhost:8000` with `WORKSHOP_MODE=true`
+
+If you closed your terminal since Tutorial 2, restart the server:
+
+```bash
+cd backend
+uvicorn app.main:app --reload --port 8000
+```
+
+Then verify:
+
+```bash
+curl http://localhost:8000/health
+# → {"status": "healthy"}
+```
+
+If the server is not running or `WORKSHOP_MODE=true` is missing from `.env`, see [SETUP.md](../SETUP.md).
 
 > New to Hedera terms? See the [Glossary](../GLOSSARY.md).
 


### PR DESCRIPTION
## Summary

- Creates `docs/workshop/SETUP.md` — a single setup guide covering server startup, `WORKSHOP_MODE` env vars, ZeroDB credentials, and a troubleshooting table
- Replaces the vague "before you start" blurb in Tutorial 1 with a full **Prerequisites** section linking to SETUP.md, with inline health-check and startup commands
- Adds matching **Prerequisites** sections to Tutorials 2 and 3 (server restart reminder + link to SETUP.md)

Closes #325 — tutorials had no server startup instructions (show-stopper)
Closes #326 — `WORKSHOP_MODE=true` was never documented, causing 404 on all tutorial API calls

## Test plan

- [ ] Fresh clone: follow SETUP.md end-to-end, confirm server starts and health check passes
- [ ] Confirm `WORKSHOP_MODE=true` + `WORKSHOP_DEFAULT_PROJECT_ID` in `.env` makes `/api/v1/agents` return 200
- [ ] Confirm missing `WORKSHOP_MODE` still returns 404 (middleware off by default)
- [ ] Walk Tutorial 1 Step 1 with workshop mode on — agent creation succeeds
- [ ] Static review: all three tutorials have Prerequisites sections with server startup and SETUP.md link

Built by AINative Dev Team