### PR TITLE
docs(tutorial-01): callouts for _pending DID and Step 5 404 in mock mode

### DIFF
--- a/docs/workshop/tutorials/01-identity-and-memory.md
+++ b/docs/workshop/tutorials/01-identity-and-memory.md
@@ -108,6 +108,8 @@ That's it — `name` and `role` are pulled from the agent you created in Step 1,
 
 📌 **Save your `did`** — this is your agent's decentralized identity. It starts with `did:hedera:testnet:`.
 
+> **Note — `_pending` suffix in workshop / mock mode:** In mock mode the server has no live Hedera connection, so no real token class is provisioned. The register endpoint substitutes the placeholder token ID `"0.0.pending"` and the DID-builder appends just the last segment of that string — producing `did:hedera:testnet:{agent_id}_pending`. This is the expected output in the workshop environment. A production deployment would supply a real `token_id` (e.g. `"0.0.456858"`) and the DID would instead read `did:hedera:testnet:{agent_id}_0.0.456858_1`. The `_pending` form is valid for the purposes of this tutorial. Refs #361.
+
 **Verification:** Your agent now has an HTS NFT on Hedera testnet linked to the same `agent_id` you saw in Step 1. This NFT IS your agent's identity — portable, verifiable, revocable.
 
 ---
@@ -121,6 +123,8 @@ Tell your AI:
 > 💡 **Which ID to use here?** Use the `agent_id` from Step 1 (the short `agent_abc123...` form), not the `agent_did` from Step 4. The path parameter `{agent_id}` means the ZeroDB agent ID, not the Hedera DID.
 
 ✅ **You should see:** A W3C DID Document with your agent's verification methods and service endpoints.
+
+> **Known issue in mock mode — HTTP 404 `DID not found`:** If Step 4 returned a `_pending` DID (see note above), the resolve endpoint will return a 404 because the resolve logic looks up the DID by the token-based key format (`did:hedera:testnet:{agent_id}_0.0.XXXXX_1`) rather than the `_pending` format stored in mock mode. This is a known mismatch tracked in #361. **You can continue to Step 6** — the 404 does not affect later steps. The code fix is in progress; the tutorial completes successfully at 10/11 steps in mock mode.
 
 **What this means:** Any system in the world can verify your agent's identity by resolving this DID. No central authority needed.
 


### PR DESCRIPTION
## Summary

- Adds a **Note** callout after the Step 4 success block explaining that `did:hedera:testnet:{agent_id}_pending` is the expected mock-mode DID format (no live Hedera token provisioned; placeholder `0.0.pending` produces the `_pending` suffix).
- Adds a **Known Issue** callout at Step 5 warning that the resolve endpoint returns HTTP 404 in mock mode because it keys on the token-based DID format rather than `_pending`, and instructing participants to continue to Step 6 unblocked.
- No code changes — documentation only. The underlying code fix is tracked in #361.

## Test plan

- [ ] Read through Steps 4–5 in the rendered tutorial and confirm both callouts display correctly
- [ ] Confirm no other steps are affected
- [ ] Confirm E2E workshop test still records 10/11 for Tutorial 01 (Step 5 acknowledged skip)

Refs #361

Built by AINative Dev Team