### PR TITLE
fix(tutorial-01) + docs: Step 10 verify param + sub-agent spawning preamble

### DIFF
--- a/docs/development-guides/SPAWNING_SUB_AGENTS_GUIDE.md
+++ b/docs/development-guides/SPAWNING_SUB_AGENTS_GUIDE.md
@@ -1,0 +1,90 @@
+# Spawning Sub-Agent Tasks — Developer Guide
+
+## Problem
+
+When the main session spawns sub-agents via `mcp__ccd_session__spawn_task`, the Task tool, or similar mechanisms, the sub-agent reads the project context file on start but does NOT automatically receive:
+
+- The Cody persona and identity rules (`.ainative/CODY.md`)
+- The Red → Green → Refactor 3-commit cadence (`.ainative/RULES.MD`, section 12)
+- The PR evidence requirement (`.claude/skills/mandatory-tdd/SKILL.md`)
+
+**Observed result (PRs #349, #350, #351):** sub-agents mix test + implementation into single commits, skip refactor commits, and omit test output from PR descriptions.
+
+## Solution: Always Prepend the Preamble
+
+Every sub-agent task prompt MUST start with this block:
+
+```
+## AINative Cody Task Preamble
+Read and follow `.ainative/SPAWN_TASK_PREAMBLE.md` before any action.
+You are Cody. Red → Green → Refactor. PR evidence mandatory.
+```
+
+The full boilerplate lives in `.ainative/SPAWN_TASK_PREAMBLE.md` (9 sections).
+
+## Example: Spawning a Compliant Sub-Agent
+
+```python
+task_prompt = """
+## AINative Cody Task Preamble
+Read and follow `.ainative/SPAWN_TASK_PREAMBLE.md` before any action.
+You are Cody. Red → Green → Refactor. PR evidence mandatory.
+
+---
+
+## Task: Fix ZeroDB mock mode short-circuit — Refs #345
+
+The `query_rows` call in mock mode hits the network instead of
+returning fixture data. Fix it so that when ZERODB_MOCK_MODE=true,
+the endpoint returns mock fixtures without making any HTTP calls.
+
+## Acceptance Criteria
+- [ ] `ZERODB_MOCK_MODE=true` returns fixture data
+- [ ] No HTTP calls made in mock mode (verify with spy)
+- [ ] Tests follow `class Describe* / def it_*` style
+- [ ] Three commits: test: → fix: → refactor:
+- [ ] Coverage >= 80% with actual pytest output in PR
+"""
+```
+
+## Expected Commit Sequence
+
+```
+test: red tests for ZeroDB mock mode short-circuit — Refs #345
+fix: short-circuit query_rows when ZERODB_MOCK_MODE=true — Refs #345
+refactor: extract mock_fixture_response helper — Refs #345
+```
+
+## PR Evidence Block (Required)
+
+The spawned agent MUST include this in the PR description:
+
+```
+## Test Execution Evidence
+
+### Command Run:
+`python3 -m pytest tests/test_zerodb_mock.py -v --cov=app.services.zerodb --cov-report=term-missing`
+
+### Output:
+test_returns_fixture_data_in_mock_mode PASSED              [ 25%]
+test_no_http_calls_in_mock_mode PASSED                     [ 50%]
+test_real_mode_still_hits_network PASSED                   [ 75%]
+test_env_var_toggle_works PASSED                           [100%]
+==================== 4 passed in 0.31s ====================
+
+### Coverage Report:
+app/services/zerodb.py    87    11    87%
+```
+
+## Enforcement
+
+- **Parent session:** always prepend the preamble when spawning.
+- **Sub-agent:** read `.ainative/SPAWN_TASK_PREAMBLE.md` as the first action.
+- **PR review:** any PR from a spawned agent missing 3-commit cadence or test evidence is returned for correction.
+
+## References
+
+- Full boilerplate: `.ainative/SPAWN_TASK_PREAMBLE.md`
+- Rules reference: `.ainative/RULES.MD` section 12
+- TDD skill: `.claude/skills/mandatory-tdd/SKILL.md`
+- Issue: [#353](https://github.com/AINative-Studio/Agent-402/issues/353)

--- a/docs/workshop/tutorials/01-identity-and-memory.md
+++ b/docs/workshop/tutorials/01-identity-and-memory.md
@@ -322,9 +322,9 @@ Finally, check the agent's cognitive profile:
 
 Tell your AI:
 
-> "Fetch the HCS audit trail for memory `{memory_id}` via `GET http://localhost:8000/anchor/{memory_id}/verify`. Return the HCS `topic_id` and `sequence_number`."
+> "Fetch the HCS audit trail for memory `{memory_id}` via `GET http://localhost:8000/anchor/{memory_id}/verify?current_content={memory_content}` — replace `{memory_id}` with the ID from Step 7 and `{memory_content}` with the exact content string you stored. Return the HCS `topic_id` and `sequence_number`."
 
-> ⚠️ **Note:** The anchor endpoint does **not** have an `/api/v1/` or `/v1/public/` prefix — use the path exactly as shown: `GET http://localhost:8000/anchor/{memory_id}/verify`.
+> ⚠️ **Note:** The anchor endpoint does **not** have an `/api/v1/` or `/v1/public/` prefix — use the path exactly as shown. The `current_content` query parameter is **required** — the endpoint returns 422 without it. Pass the exact content string from Step 7 so the server can hash it and compare against the HCS-recorded hash.
 
 ✅ **You should see:**
 ```json


### PR DESCRIPTION
## Changes

### fix(tutorial-01): required `current_content` param in Step 10 verify prompt

- Step 10 of Tutorial 01 told vibe-coders to call `GET /anchor/{memory_id}/verify` with no query parameters
- The endpoint requires `?current_content=<text>` and returns 422 without it
- Updated the AI prompt to include `?current_content={memory_content}` with a clear substitution instruction
- Updated the note to call out that `current_content` is required and explain why (the server hashes the supplied text and compares it against the HCS-recorded hash)

### docs: SPAWN_TASK_PREAMBLE.md and sub-agent spawning guide — Closes #353

Sub-agents spawned via the Task tool receive the project context file but not the Cody persona, Red→Green→Refactor commit cadence, or PR evidence requirements. Observed impact: PRs #349, #350, #351 all mixed test + implementation into single commits and omitted test output.

**`.ainative/SPAWN_TASK_PREAMBLE.md`** (committed in core, live via symlink)

9-section boilerplate that every spawned task prompt must prepend:
1. Cody persona
2. Red → Green → Refactor 3-commit cadence
3. PR evidence (pytest output, coverage >= 80%)
4. BDD test style (`class Describe* / def it_*`)
5. Commit rules (branch naming, attribution ban, Fibonacci, issue refs)
6. File placement
7. Issue tracking
8. Security and compliance
9. Delivery checklist

**`.ainative/RULES.MD` section 12** — "Spawning Sub-Agent Tasks" (committed in core, live via symlink)

**`docs/development-guides/SPAWNING_SUB_AGENTS_GUIDE.md`** — usage guide with example task prompt, expected 3-commit sequence, and PR evidence format.

## Usage

Every sub-agent task prompt starts with:

```
## AINative Cody Task Preamble
Read and follow `.ainative/SPAWN_TASK_PREAMBLE.md` before any action.
You are Cody. Red → Green → Refactor. PR evidence mandatory.
```

## Notes on `.ainative` changes

The `.ainative/` directory is a symlink to `AINative-Studio/core`. The RULES.MD and SPAWN_TASK_PREAMBLE.md changes are committed in core on branch `docs/agent402-353-spawn-task-preamble` and are live immediately via the symlink.

## Risk / Rollback

Documentation-only. No code or API changes. Rollback: revert the guide file in this repo and revert core branch.

Closes #353
Built by AINative Dev Team